### PR TITLE
13 ray path

### DIFF
--- a/src/raypyng/runner.py
+++ b/src/raypyng/runner.py
@@ -167,7 +167,7 @@ class RayUIRunner:
             str: string with the detected RAY-UI installation path
         """
         basepaths = ("~", "~/Applications","/opt","/Applications")
-        installpaths = ("RAY-UI-development","RAY-UI")
+        installpaths = ("RAY-UI-development","RAY-UI", "Ray-UI")
         pathlist = [os.path.expanduser(p) for p in [os.path.join(x,y) for x in basepaths for y in installpaths]]
 
         for ray_path in pathlist:

--- a/src/raypyng/runner.py
+++ b/src/raypyng/runner.py
@@ -169,11 +169,10 @@ class RayUIRunner:
         basepaths = ("~", "~/Applications","/opt","/Applications")
         installpaths = ("RAY-UI-development","RAY-UI", "Ray-UI")
         pathlist = [os.path.expanduser(p) for p in [os.path.join(x,y) for x in basepaths for y in installpaths]]
-
         for ray_path in pathlist:
             if os.path.isdir(ray_path):
                 return ray_path
-        raise RayPyRunnerError("Can not detect rayui installation path!")
+        raise RayPyRunnerError("Can not detect rayui installation path! Please provide it manually")
  
 ###############################################################################
 class RayUIAPI:

--- a/src/raypyng/simulate.py
+++ b/src/raypyng/simulate.py
@@ -827,6 +827,11 @@ class Simulate():
         """
         if not isinstance(multiprocessing, int) or multiprocessing < 1:
             raise ValueError("The 'multiprocessing' argument must be an integer greater than 0.")
+        
+        # test that we car run RAY-UI
+        runner = RayUIRunner(ray_path=self.ray_path, hide=True)
+        runner.kill()
+
         self._batch_number = 0
         self._workers = multiprocessing
         self.batch_size = int(self._workers)*5  
@@ -1079,7 +1084,6 @@ def run_rml_func(parameters):
     """
     st = time.time()
     (rml_filename, hide, analyze, raypyng_analysis, ray_path), exports = parameters
-
     runner = RayUIRunner(ray_path=ray_path, hide=hide)
     api = RayUIAPI(runner)
     pp = PostProcess()

--- a/src/raypyng/simulate.py
+++ b/src/raypyng/simulate.py
@@ -852,8 +852,7 @@ class Simulate():
             pp = PostProcess()
             pp.cleanup(self.sim_path, self.repeat, self._exported_obj_names_list)
             self.logger.info('Done with the cleanup')
-        self.logger.info('Brute force exit')
-        os._exit(0) # exit brute force
+        self.logger.info('End of the Simulations')
         
 
     def _remove_recap_files(self,):


### PR DESCRIPTION
- add new standard installation to ray_path
- remove brute force exit at the end of the simulations
- test if the runner can start before starting the multiprocessing simulations: this catches eventual problems with the ray_path before starting multiprocessing.