### PR TITLE
1.2.81

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raypyng"
-version = "1.2.8"
+version = "1.2.81"
 
 authors = [
   { name="Simone Vadilonga, Ruslan Ovsyannikov, Sebastian Sachse", email="simone.vadilonga@helmholtz-berlin.de" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raypyng"
-version = "1.2.7"
+version = "1.2.8"
 
 authors = [
   { name="Simone Vadilonga, Ruslan Ovsyannikov, Sebastian Sachse", email="simone.vadilonga@helmholtz-berlin.de" },

--- a/src/raypyng/simulate.py
+++ b/src/raypyng/simulate.py
@@ -1013,18 +1013,10 @@ class Simulate():
             try:
                 for sim in simulation_params_batch:
                     _,exp_list = sim
-                    # self.logger.info(f'Extracting exp_list {type(exp_list)}, {exp_list}')
                     exp = exp_list[0]
-                    # self.logger.info(f'Extracting exp {type(exp)}, {exp}')
-                    # self.logger.info(f'Extracting exp[-2] {type(exp[-2])}, {exp[-2]}')
-                    # self.logger.info(f'Extracting exp[-1] {type(exp[-1])}, {exp[-1]}')
-                    round_n = int(re.findall(r'\d+', exp[-2])[0])
-                    # self.logger.info('Extracting sim_n')
+                    round_n = int(re.findall(r'(?<=round_)\d+', exp[-2])[0])
                     sim_n = int(re.findall(r'\d+', exp[-1])[0])
-                    # self.logger.info(f'round_n: {round_n}')
-                    # self.logger.info(f'sim_n: {sim_n}')
                     sim_file = sim[0][0]
-                    # self.logger.info(f'Waiting for {sim_file}')
                     while self._is_simulation_missing(sim_n, round_n):
                         time.sleep(5)
                         self.logger.info(f'Waiting for file {sim_file}')


### PR DESCRIPTION
- Simulations do not hang forever now, there was an error in the way the simulations file name was constructed.
- The simulation.run function will now brute force terminate, unless the the parameter force_exit is set to False. As a side effect nothing after that line will run.
- Now the recap file is updated only once, and not more.