### PR TITLE
Save space on disk

### DIFF
--- a/examples/example_simulation_noanalyze.py
+++ b/examples/example_simulation_noanalyze.py
@@ -14,8 +14,8 @@ elisa = sim.rml.beamline
 
 # define the values of the parameters to scan 
 energy    = np.arange(200, 7201,250)
-SlitSize  = np.array([0.1])
-cff       = np.array([2.25, 3])
+SlitSize  = np.array([0.1, 0.2])
+cff       = np.array([2.25])
 nrays     = 5e4
 
 # define a list of dictionaries with the parameters to scan
@@ -43,11 +43,11 @@ sim.raypyng_analysis=True # let raypyng analyze the results
 
 ## This must be a list of dictionaries
 sim.exports  =  [{elisa.Dipole:['RawRaysOutgoing']},
-                {elisa.DetectorAtFocus:['RawRaysOutgoing']},
+                {elisa.DetectorAtFocus:['RawRaysOutgoing']}
                 ]
 
 #uncomment to run the simulations
-sim.run(multiprocessing=1, force=True, remove_rawrays=True)
+sim.run(multiprocessing=5, force=True, remove_rawrays=True)
 
 
 

--- a/examples/example_simulation_noanalyze.py
+++ b/examples/example_simulation_noanalyze.py
@@ -14,9 +14,9 @@ elisa = sim.rml.beamline
 
 # define the values of the parameters to scan 
 energy    = np.arange(200, 7201,250)
-SlitSize  = np.array([0.1, 0.2])
-cff       = np.array([2.25])
-nrays     = 10000
+SlitSize  = np.array([0.1])
+cff       = np.array([2.25, 3])
+nrays     = 5e4
 
 # define a list of dictionaries with the parameters to scan
 params = [  
@@ -43,11 +43,11 @@ sim.raypyng_analysis=True # let raypyng analyze the results
 
 ## This must be a list of dictionaries
 sim.exports  =  [{elisa.Dipole:['RawRaysOutgoing']},
-                {elisa.DetectorAtFocus:['RawRaysOutgoing']}
+                {elisa.DetectorAtFocus:['RawRaysOutgoing']},
                 ]
 
 #uncomment to run the simulations
-sim.run(multiprocessing=5, force=True)
+sim.run(multiprocessing=1, force=True, remove_rawrays=True)
 
 
 

--- a/examples/example_simulation_noanalyze_save_space.py
+++ b/examples/example_simulation_noanalyze_save_space.py
@@ -1,0 +1,54 @@
+from raypyng import Simulate
+import numpy as np
+import os
+
+this_file_dir=os.path.dirname(os.path.realpath(__file__))
+rml_file = os.path.join(this_file_dir,'rml/elisa.rml')
+
+sim = Simulate(rml_file, hide=True)
+
+rml=sim.rml
+elisa = sim.rml.beamline
+
+
+
+# define the values of the parameters to scan 
+energy    = np.arange(200, 7201,250)
+SlitSize  = np.array([0.1])
+cff       = np.array([2.25, 3])
+nrays     = 5e3
+
+# define a list of dictionaries with the parameters to scan
+params = [  
+            # set two parameters: "alpha" and "beta" in a dependent way. 
+            {elisa.Dipole.photonEnergy:energy}, 
+            # set a range of  values 
+            {elisa.ExitSlit.totalHeight:SlitSize},
+            # set values 
+            {elisa.PG.cFactor:cff},
+            {elisa.Dipole.numberRays:nrays}
+        ]
+
+#and then plug them into the Simulation class
+sim.params=params
+
+# sim.simulation_folder = '/home/simone/Documents/RAYPYNG/raypyng/test'
+sim.simulation_name = 'test_noAnalyze_saveSpace'
+
+# repeat the simulations as many time as needed
+sim.repeat = 2
+
+sim.analyze = False # don't let RAY-UI analyze the results
+sim.raypyng_analysis=True # let raypyng analyze the results
+
+## This must be a list of dictionaries
+sim.exports  =  [{elisa.Dipole:['RawRaysOutgoing']},
+                {elisa.DetectorAtFocus:['RawRaysOutgoing']},
+                ]
+
+#uncomment to run the simulations
+sim.run(multiprocessing=5, force=True, remove_rawrays=True, remove_round_folders=True)
+
+
+
+        

--- a/src/raypyng/postprocessing.py
+++ b/src/raypyng/postprocessing.py
@@ -1,5 +1,7 @@
 from importlib.resources import path
 import numpy as np
+import pandas as pd
+from pathlib import Path
 import os
 import warnings
 from natsort import natsorted, ns
@@ -211,7 +213,9 @@ class PostProcess():
         
         return float(energy)
     
-    def postprocess_RawRays(self,exported_element:str=None, exported_object:str=None, dir_path:str=None, sim_number:str=None, rml_filename:str=None, suffix:str=None):
+    def postprocess_RawRays(self,exported_element:str=None, exported_object:str=None, 
+                            dir_path:str=None, sim_number:str=None, rml_filename:str=None, 
+                            suffix:str=None, remove_rawrays:bool=False):
         """ PostProcess routine of the RawRaysOutgoing extracted files.
 
         The method looks in the folder dir_path for a file with the filename:
@@ -284,6 +288,8 @@ class PostProcess():
                 ray_properties['GaAsPCurrentAmp'] = np.nan
         new_filename = os.path.join(dir_path, sim_number+exported_element+'_analyzed_rays'+suffix+'.dat')
         ray_properties.save(new_filename)
+        if remove_rawrays:
+            remove_file(filename)
         return 
 
     def _flux_permil_perbw(self, bandwidth, source_bandwidth,  photon_flux):
@@ -452,3 +458,9 @@ class PostProcessAnalyzed():
         return np.convolve(x, np.ones(w), 'valid') / w
 
 
+def remove_file(file_path):
+    p = Path(file_path)
+    try:
+        p.unlink()
+    except Exception as e:
+        print(f"Failed to remove {file_path}: {e}")

--- a/src/raypyng/postprocessing.py
+++ b/src/raypyng/postprocessing.py
@@ -333,6 +333,7 @@ class PostProcess():
                             tmp = RayProperties(filename=f)
                             for n in analyzed_rays.dtype.names: 
                                 analyzed_rays[n][f_ind] += tmp[n]
+                        os.remove(f)
                 # take the average
                 for n in analyzed_rays.dtype.names:
                     analyzed_rays[n] /= repeat


### PR DESCRIPTION
If raypyng is doing the analysis, it means that RawRays files are exported, which can be pretty large. This pull request introduces the following changes:

- individual analyzed rays files are deleted once they have been summarized.
- when running the simulations it is now possible to set the following two parameters:
  - remove_rawrays (bool, optional): removes RawRaysIncoming and RawRaysOutgoing files, if present.
  - remove_round_folders (bool, optional): remove the round folders after the simulations are done.