### PR TITLE
[codex] Fix simulation shutdown and cleanup handling

### DIFF
--- a/examples/simulation_save_space.py
+++ b/examples/simulation_save_space.py
@@ -13,7 +13,7 @@ beamline = sim.rml.beamline
 
 
 # define the values of the parameters to scan 
-energy    = np.arange(200, 7201,250)
+energy    = np.arange(200, 7201,1)
 SlitSize  = np.array([0.1])
 cff       = np.array([2.25, 3])
 nrays     = 5e3
@@ -47,7 +47,7 @@ sim.exports  =  [{beamline.Dipole:['RawRaysOutgoing']},
                 ]
 
 #uncomment to run the simulations
-sim.run(multiprocessing=5, force=True, remove_rawrays=True, remove_round_folders=True)
+sim.run(multiprocessing=30, force=True, remove_rawrays=True, remove_round_folders=True)
 
 
 

--- a/examples/simulation_save_space.py
+++ b/examples/simulation_save_space.py
@@ -13,7 +13,7 @@ beamline = sim.rml.beamline
 
 
 # define the values of the parameters to scan 
-energy    = np.arange(200, 7201,1)
+energy    = np.arange(200, 7201,15)
 SlitSize  = np.array([0.1])
 cff       = np.array([2.25, 3])
 nrays     = 5e3

--- a/src/raypyng/postprocessing.py
+++ b/src/raypyng/postprocessing.py
@@ -109,6 +109,11 @@ class PostProcess:
         # Assuming natsorted and ns are properly imported and available in the context
         return natsorted(res, alg=ns.IGNORECASE)
 
+    def _extract_sim_index(self, filepath: str):
+        filename = os.path.basename(filepath)
+        sim_index = filename.split("_", 1)[0]
+        return int(sim_index) if sim_index.isdigit() else None
+
     def _extract_fwhm(self, rays: np.array):
         """Calculate the fwhm of the rays.
 
@@ -499,25 +504,48 @@ class PostProcess:
             repeat (int, optional): number of rounds of simulations. Defaults to 1.
             exp_elements (list, optional): the exported elements names as str. Defaults to None.
         """
+        expected_simulations = len(
+            {
+                self._extract_sim_index(path)
+                for path in self._list_files(
+                    os.path.join(dir_path, "round_0"),
+                    contain_str=".rml",
+                )
+                if self._extract_sim_index(path) is not None
+            }
+        )
         for d in exp_elements:
             for exp in exported_file_type:
+                analyzed_rays = None
                 for round in range(repeat):
                     dir_path_round = os.path.join(dir_path, "round_" + str(round))
                     files = self._list_files(
                         dir_path_round, d + "_analyzed_rays_" + exp + self.format_saved_files
                     )
-                    for f_ind, f in enumerate(files):
-                        if round == 0 and f_ind == 0:  # first round, first file, create
-                            analyzed_rays = pd.read_csv(f)
-                        elif round == 0 and f_ind != 0:  # first round, following files, concatenate
-                            tmp = pd.read_csv(f)
-                            analyzed_rays = pd.concat([analyzed_rays, tmp], ignore_index=True)
-                        elif round >= 1:  # other rounds: sum the values
-                            tmp = pd.read_csv(f)
-                            for n in analyzed_rays.columns:
-                                if isinstance(tmp.loc[0, n], (int, float)):
-                                    analyzed_rays.loc[f_ind, n] += float(tmp.loc[0, n])
+                    for f in files:
+                        sim_index = self._extract_sim_index(f)
+                        if sim_index is None or sim_index >= expected_simulations:
+                            continue
+                        tmp = pd.read_csv(f)
+                        tmp["_sim_index"] = sim_index
+                        if round == 0 and analyzed_rays is None:
+                            analyzed_rays = tmp
+                            analyzed_rays.set_index("_sim_index", inplace=True)
+                        elif round == 0:
+                            tmp.set_index("_sim_index", inplace=True)
+                            analyzed_rays = pd.concat([analyzed_rays, tmp], axis=0)
+                        else:
+                            tmp.set_index("_sim_index", inplace=True)
+                            if sim_index not in analyzed_rays.index:
+                                analyzed_rays = pd.concat([analyzed_rays, tmp], axis=0)
+                            else:
+                                for n in analyzed_rays.columns:
+                                    if isinstance(tmp.iloc[0][n], (int, float)):
+                                        analyzed_rays.loc[sim_index, n] += float(tmp.iloc[0][n])
                         os.remove(f)
+
+                if analyzed_rays is None:
+                    continue
 
                 def divide_numeric_rows(row):
                     # Check if all elements in the row are of a numeric type
@@ -527,6 +555,7 @@ class PostProcess:
                         return row
 
                 analyzed_rays = analyzed_rays.apply(divide_numeric_rows, axis=1)
+                analyzed_rays = analyzed_rays.sort_index().reset_index(drop=True)
                 # Apply the function across the DataFrame
                 # save the file
                 fn = os.path.join(dir_path, d + "_" + exp + ".csv")

--- a/src/raypyng/runner.py
+++ b/src/raypyng/runner.py
@@ -4,6 +4,8 @@
 # from sre_constants import SUCCESS
 import atexit
 import os
+import select
+import signal
 import subprocess
 import time
 
@@ -72,12 +74,13 @@ class RayUIRunner:
         self._process = None
         self._verbose = False
         if hide:
-            self._hide = "xvfb-run --auto-servernum --server-num=3000 "
+            self._hide = ["xvfb-run", "--auto-servernum", "--server-num=3000"]
         else:
-            self._hide = ""
+            self._hide = []
 
         # internal configuration parameters
         self._auto_flush = True  # flush on write calls
+        self._stdout_buffer = bytearray()
 
     def run(self):
         """Open one instance of RAY-UI using subprocess
@@ -90,16 +93,20 @@ class RayUIRunner:
             fullpath = os.path.join(self._path, self._binary)
             if not os.path.isfile(fullpath):
                 raise RayPyRunnerError("Ray executable {0} is not found".format(fullpath))
-            fullpath = self._hide + fullpath
+            cmd = [*self._hide, fullpath]
+            if self._options:
+                cmd.append(self._options)
             env = dict(os.environ)  # TODO:: rethink a bit about this line
             self._process = subprocess.Popen(
-                fullpath + " -b",
-                shell=True,
+                cmd,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 env=env,
+                start_new_session=True,
             )
+            os.set_blocking(self._process.stdout.fileno(), False)
+            self._stdout_buffer.clear()
             atexit.register(self.kill)
         return self
 
@@ -113,22 +120,33 @@ class RayUIRunner:
         if self._process is None:
             return False
         else:
-            poll_result = self._process.poll()
-            if poll_result is not None:
-                # we have an exit code, so process is not valid any more and clean it it up
-                self._process = None
-                return False
-            else:
-                return True
+            return self._process.poll() is None
 
     def kill(self):
         """kill a RAY-UI process"""
+        if self._process is None:
+            return
+
         if self.isrunning:
             pid = self._process.pid
-            process = psutil.Process(pid)
-            for proc in process.children(recursive=True):
-                proc.kill()
-            process.kill()
+            try:
+                os.killpg(pid, signal.SIGTERM)
+                self._process.wait(timeout=5)
+            except (ProcessLookupError, subprocess.TimeoutExpired):
+                try:
+                    process = psutil.Process(pid)
+                    for proc in process.children(recursive=True):
+                        proc.kill()
+                    process.kill()
+                except psutil.NoSuchProcess:
+                    pass
+                try:
+                    os.killpg(pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+
+        self._close_pipes()
+        self._process = None
 
     @property
     def pid(self):
@@ -166,13 +184,65 @@ class RayUIRunner:
         Returns:
             str: line read from the input
         """
-        if self.isrunning:
-            line = self._process.stdout.readline().decode("utf8").rstrip("\n")
-            if self._verbose:  # verbose
-                print(line)
-            return line
-        else:
+        return self._readline_with_timeout(timeout=None)
+
+    def _readline_with_timeout(self, timeout=None) -> str:
+        """Read one line from stdout, optionally timing out if no new line arrives."""
+        if not self.isrunning:
             return None
+
+        deadline = None if timeout is None else time.monotonic() + timeout
+        stdout_fd = self._process.stdout.fileno()
+
+        while True:
+            newline_index = self._stdout_buffer.find(b"\n")
+            if newline_index != -1:
+                line = self._stdout_buffer[:newline_index]
+                del self._stdout_buffer[: newline_index + 1]
+                decoded_line = line.decode("utf8", errors="replace").rstrip("\r")
+                if self._verbose:
+                    print(decoded_line)
+                return decoded_line
+
+            if not self.isrunning:
+                if self._stdout_buffer:
+                    line = self._stdout_buffer.decode("utf8", errors="replace").rstrip("\r")
+                    self._stdout_buffer.clear()
+                    if self._verbose:
+                        print(line)
+                    return line
+                return None
+
+            wait_time = None
+            if deadline is not None:
+                wait_time = max(0.0, deadline - time.monotonic())
+                if wait_time == 0.0:
+                    return None
+
+            readable, _, _ = select.select([stdout_fd], [], [], wait_time)
+            if not readable:
+                return None
+
+            chunk = os.read(stdout_fd, 4096)
+            if not chunk:
+                if self._stdout_buffer:
+                    line = self._stdout_buffer.decode("utf8", errors="replace").rstrip("\r")
+                    self._stdout_buffer.clear()
+                    if self._verbose:
+                        print(line)
+                    return line
+                return None
+            self._stdout_buffer.extend(chunk)
+
+    def _close_pipes(self):
+        for stream_name in ("stdin", "stdout", "stderr"):
+            stream = getattr(self._process, stream_name, None)
+            if stream is not None:
+                try:
+                    stream.close()
+                except Exception:
+                    pass
+        self._stdout_buffer.clear()
 
     def __detect_ray_path(self) -> str:
         """Internal function to autodetect installation path of RAY-UI
@@ -309,10 +379,14 @@ class RayUIAPI:
         # and once as status return
         cmd_seen = False
         while True:
-            line = self._runner._readline()
+            poll_timeout = self._read_wait_delay if timeout is not None else None
+            line = self._runner._readline_with_timeout(timeout=poll_timeout)
             if line is None:
-                time.sleep(self._read_wait_delay)
+                if timeout is None:
+                    continue
                 timecnt += self._read_wait_delay
+                if timecnt > timeout:
+                    raise TimeoutError("timeout while waiting ray command io")
                 continue
             if line.startswith(cmd):
                 if cmd_seen:
@@ -322,6 +396,4 @@ class RayUIAPI:
             else:
                 if cbdataread is not None:
                     cbdataread(line)
-            if timeout is not None and timecnt > timeout:
-                raise TimeoutError("timeout while waiting ray command io")
         return line.lstrip(cmd).strip()

--- a/src/raypyng/simulate.py
+++ b/src/raypyng/simulate.py
@@ -871,7 +871,7 @@ class Simulate:
             bool: True if the simulation is missing any export files, False otherwise.
         """
         round_folder = "round_" + str(repeat)
-        folder = os.path.join(self._sim_folder, round_folder)
+        folder = os.path.join(self.sim_path, round_folder)
         for export_config in self._exports_list:
             if self.raypyng_analysis:
                 export_file = os.path.join(
@@ -885,6 +885,48 @@ class Simulate:
                 return True  # Missing at least one export file
 
         return False
+
+    def _missing_simulations_for_round(self, round_number):
+        """Return missing simulation indices for a round using a single directory scan."""
+        round_folder = os.path.join(self.sim_path, "round_" + str(round_number))
+        expected_ids = set(range(self.sp._calc_number_sim()))
+
+        if self.raypyng_analysis:
+            expected_suffixes = [
+                f"_{export_config[0]}_analyzed_rays_{export_config[1]}.dat"
+                for export_config in self._exports_list
+            ]
+        else:
+            expected_suffixes = [
+                f"_{export_config[0]}-{export_config[1]}.csv" for export_config in self._exports_list
+            ]
+
+        found_per_export = {suffix: set() for suffix in expected_suffixes}
+        self.logger.info(f"Scanning round {round_number} outputs in {round_folder}")
+
+        with os.scandir(round_folder) as entries:
+            for entry in entries:
+                if not entry.is_file():
+                    continue
+                filename = entry.name
+                for suffix in expected_suffixes:
+                    if not filename.endswith(suffix):
+                        continue
+                    sim_index = filename[: -len(suffix)].split("_", 1)[0]
+                    if sim_index.isdigit():
+                        sim_index = int(sim_index)
+                        if sim_index in expected_ids:
+                            found_per_export[suffix].add(sim_index)
+                    break
+
+        completed_ids = expected_ids.copy()
+        for suffix, found_ids in found_per_export.items():
+            self.logger.info(
+                f"Round {round_number}: found {len(found_ids)}/{len(expected_ids)} files for {suffix}"
+            )
+            completed_ids &= found_ids
+
+        return sorted(expected_ids - completed_ids)
 
     def _make_exports_list(self, sim_number, round_n):
         exports_list = []
@@ -1005,15 +1047,22 @@ class Simulate:
         self._init_logging()
         total_simulations = self.sp._calc_number_sim() * self.repeat
         self.simulations_checked = False
+        self._executor_has_unfinished_futures = False
 
         pbar = self._initialize_progress_bar(total_simulations, description="Simulations Completed")
         try:
             self._execute_simulations(multiprocessing, force, total_simulations, pbar)
-            pbar.close()
             self.logger.info("Simulation completed successfully.")
         except KeyboardInterrupt:
             self.logger.error("Simulation Interrupted.", exc_info=True)
             self.cleanup_child_processes()
+            raise
+        except Exception:
+            self.logger.error("Simulation failed.", exc_info=True)
+            self.cleanup_child_processes()
+            raise
+        finally:
+            pbar.close()
         if self.raypyng_analysis:
             self.logger.info("Starting cleanup")
             pp = PostProcess()
@@ -1039,11 +1088,14 @@ class Simulate:
         and any specific Xvfb processes."""
         current_process = psutil.Process()
         children = current_process.children(recursive=True)
+        announced_cleanup = False
 
         # First, terminate general child processes
         for child in children:
             try:
-                print(f"Terminating child process {child.pid}")
+                if not announced_cleanup:
+                    print("Terminating child processes...")
+                    announced_cleanup = True
                 child.terminate()
                 child.wait(timeout=3)  # Give it some time to gracefully shut down
             except psutil.NoSuchProcess:
@@ -1129,53 +1181,72 @@ class Simulate:
         """
         simulations_durations = []  # Track durations of all simulations for average calculation
         executor = None
+        rerun_missing = False
+        rerun_pbar = None
 
         try:
-            with ProcessPoolExecutor(max_workers=multiprocessing) as executor:
-                simulation_params_batch = []
-                batch_length = 0
-                remaining_simulations = total_simulations
-                for round_number in range(self.repeat):
-                    self.logger.info(f"Start round {round_number}")
-                    for sim_number, params in enumerate(self.sp.simulation_parameters_generator()):
-                        if round_number == 0 and update_reacap_files is True:
-                            self._update_simulation_recap_files(params, sim_number)
-                        if self._is_simulation_missing(sim_number, round_number) or force:
-                            self._prepare_and_submit_simulation(
-                                params,
-                                sim_number,
-                                round_number,
-                                simulation_params_batch,
-                                executor,
-                                force,
-                            )
-                        else:
-                            pbar.update(1)  # If not missing or forced, update progress bar directly
-                        batch_length += 1
-                        remaining_simulations -= 1
-                        if batch_length == self.batch_size or remaining_simulations == 0:
-                            self._wait_for_simulation_batch(
-                                simulations_durations, simulation_params_batch, executor, pbar
-                            )
-                            self.logger.info(
-                                f"Waiting For batch, {self.batch_size} simulations to go"
-                            )
-                            batch_length = 0
-                        if remaining_simulations == 0:
-                            self.logger.info(
-                                f"Remaning Simulations {remaining_simulations}, \
-                                    stop the simulations loop"
-                            )
-                            self._final_check_on_simulations_and_shutdown(executor, pbar)
-                            break
+            executor = ProcessPoolExecutor(max_workers=multiprocessing)
+            simulation_params_batch = []
+            batch_length = 0
+            remaining_simulations = total_simulations
+            for round_number in range(self.repeat):
+                self.logger.info(f"Start round {round_number}")
+                for sim_number, params in enumerate(self.sp.simulation_parameters_generator()):
+                    if round_number == 0 and update_reacap_files is True:
+                        self._update_simulation_recap_files(params, sim_number)
+                    if self._is_simulation_missing(sim_number, round_number) or force:
+                        self._prepare_and_submit_simulation(
+                            params,
+                            sim_number,
+                            round_number,
+                            simulation_params_batch,
+                            executor,
+                            force,
+                        )
+                    else:
+                        pbar.update(1)  # If not missing or forced, update progress bar directly
+                    batch_length += 1
+                    remaining_simulations -= 1
+                    if batch_length == self.batch_size or remaining_simulations == 0:
+                        self._wait_for_simulation_batch(
+                            simulations_durations, simulation_params_batch, executor, pbar
+                        )
+                        self.logger.info(f"Waiting For batch, {self.batch_size} simulations to go")
+                        batch_length = 0
+                    if remaining_simulations == 0:
+                        self.logger.info(
+                            f"Remaning Simulations {remaining_simulations}, \
+                                stop the simulations loop"
+                        )
+                        rerun_missing, rerun_pbar = self._final_check_on_simulations_and_shutdown(
+                            pbar
+                        )
+                        break
         except Exception as e:
             traceback.print_exc()
             self.logger.info(f"Error in _execute simulations: {e}")
+            raise
+        finally:
             if executor is not None:
-                executor.shutdown(cancel_futures=True)
-                self.logger.info("Executor shutdown completed.")
+                shutdown_wait = not rerun_missing and not self._executor_has_unfinished_futures
+                force_cancel = rerun_missing or self._executor_has_unfinished_futures
+                executor.shutdown(wait=shutdown_wait, cancel_futures=force_cancel)
+                self.logger.info(
+                    "Executor shutdown completed%s.",
+                    " without waiting" if not shutdown_wait else "",
+                )
+                if force_cancel:
+                    self.cleanup_child_processes()
+        if rerun_missing:
+            self._execute_simulations(
+                self._workers,
+                False,
+                total_simulations,
+                rerun_pbar,
+                update_reacap_files=False,
+            )
 
-    def _final_check_on_simulations_and_shutdown(self, executor, old_pbar):
+    def _final_check_on_simulations_and_shutdown(self, old_pbar):
 
         # check that all simulatins are completed:
         self.logger.info(
@@ -1183,12 +1254,13 @@ class Simulate:
         )
         missing_sim = []
         for round_number in range(self.repeat):
-            for sim_number, _params in enumerate(self.sp.simulation_parameters_generator()):
-                if self._is_simulation_missing(sim_number, round_number):
-                    self.logger.info(
-                        f"This simulation is missing: round {round_number}, number {sim_number}"
-                    )
-                    missing_sim.append({"round": round_number, "sim_number": sim_number})
+            round_missing = self._missing_simulations_for_round(round_number)
+            self.logger.info(
+                f"Round {round_number}: final check found {len(round_missing)} missing simulations"
+            )
+            for sim_number in round_missing:
+                self.logger.info(f"This simulation is missing: round {round_number}, number {sim_number}")
+                missing_sim.append({"round": round_number, "sim_number": sim_number})
 
         if len(missing_sim) >= 1 and self.simulations_checked is False:
             self.logger.info("Finish missing simulations")
@@ -1198,9 +1270,9 @@ class Simulate:
                 total_simulations, description="Checking Simulations"
             )
             self.simulations_checked = True
-            self._execute_simulations(
-                self._workers, False, total_simulations, pbar, update_reacap_files=False
-            )
+            return True, pbar
+
+        return False, old_pbar
 
     def _prepare_and_submit_simulation(
         self, params, sim_number, round_number, simulation_params_batch, executor, force
@@ -1272,6 +1344,14 @@ class Simulate:
                 )
         except Exception as e:
             self.logger.info(f"Exception during simulation: {e}")
+            unfinished_futures = [future for future in futures if not future.done()]
+            if unfinished_futures:
+                self._executor_has_unfinished_futures = True
+                self.logger.info(
+                    f"Marking executor as having {len(unfinished_futures)} unfinished futures"
+                )
+                for future in unfinished_futures:
+                    future.cancel()
             try:
                 wait_time = self._simulation_timeout / 4
                 for sim in simulation_params_batch:

--- a/src/raypyng/simulate.py
+++ b/src/raypyng/simulate.py
@@ -960,7 +960,7 @@ class Simulate:
         multiprocessing=1,
         force=False,
         overwrite_rml=True,
-        force_exit=True,
+        force_exit=False,
         remove_rawrays=False,
         remove_round_folders=False,
     ):
@@ -978,8 +978,8 @@ class Simulate:
             force (bool, optional): Force re-execution of simulations.
                                                     Defaults to False.
             overwrite_rml (bool, optional): Overwrite existing RML files. Defaults to True.
-            force_exit (bool, optional): calls os.exit when the simulations are complete.
-                                            Nothing else will run after it. Defaults to True.
+            force_exit (bool, optional): emergency fallback that calls os._exit when the
+                                            simulations are complete. Defaults to False.
             remove_rawrays (bool, optional): removes RawRaysIncoming and RawRaysOutgoing files,
                                                 if present.
             remove_round_folders (bool, optional): remove the round folders after the simulations
@@ -1128,6 +1128,7 @@ class Simulate:
             pbar (tqdm): Progress bar object for tracking simulation progress.
         """
         simulations_durations = []  # Track durations of all simulations for average calculation
+        executor = None
 
         try:
             with ProcessPoolExecutor(max_workers=multiprocessing) as executor:
@@ -1166,13 +1167,13 @@ class Simulate:
                                     stop the simulations loop"
                             )
                             self._final_check_on_simulations_and_shutdown(executor, pbar)
-                            executor.shutdown(wait=False, cancel_futures=True)
                             break
         except Exception as e:
             traceback.print_exc()
             self.logger.info(f"Error in _execute simulations: {e}")
-            executor.shutdown(wait=False)
-            self.logger.info("Executor shutdown completed.")
+            if executor is not None:
+                executor.shutdown(cancel_futures=True)
+                self.logger.info("Executor shutdown completed.")
 
     def _final_check_on_simulations_and_shutdown(self, executor, old_pbar):
 
@@ -1188,9 +1189,6 @@ class Simulate:
                         f"This simulation is missing: round {round_number}, number {sim_number}"
                     )
                     missing_sim.append({"round": round_number, "sim_number": sim_number})
-
-        executor.shutdown(wait=False)
-        self.logger.info("Executor shutdown completed.")
 
         if len(missing_sim) >= 1 and self.simulations_checked is False:
             self.logger.info("Finish missing simulations")


### PR DESCRIPTION
## Summary

This PR fixes the shutdown path for large simulation runs that completed their output work but could still hang during executor teardown.

It also fixes cleanup aggregation when round folders contain stale analyzed-ray files from previous runs.

## What Changed

- reworked simulation executor shutdown so unfinished worker futures do not block process exit
- moved the final missing-simulation check to a directory-scan based approach instead of per-simulation existence probing
- avoided recursive retry while the previous executor is still active
- made simulation failures propagate instead of being logged as successful completion
- reduced child-process cleanup terminal spam to a single line
- fixed postprocessing cleanup to aggregate by simulation index from filenames instead of file order
- ignored stale out-of-range analyzed-ray files during final checks and cleanup aggregation

## Root Cause

There were two separate issues:

1. Simulation batches could leave unfinished futures behind even after the expected output files had been written. The final shutdown path still waited on the executor, which caused the Python process to hang during teardown.
2. Postprocessing cleanup assumed per-round files aligned by enumeration order. That breaks when old files from previous runs remain in the round folders, leading to invalid row indexing during aggregation.

## Validation

Validated through the user-supervised `simulation_save_space.py` runs that originally reproduced the hang. The updated flow now reaches normal completion, and the cleanup aggregation no longer fails on stale file indices.
