### PR TITLE
[codex] Add divergence analysis metadata sidecar

### DIFF
--- a/src/raypyng/postprocessing.py
+++ b/src/raypyng/postprocessing.py
@@ -21,6 +21,8 @@ class RayProperties:
             "Bandwidth",
             "HorizontalFocusFWHM",
             "VerticalFocusFWHM",
+            "HorizontalDivergenceFWHM",
+            "VerticalDivergenceFWHM",
             "HorizontalCenter",
             "VerticalCenter",
         ]
@@ -153,6 +155,14 @@ class PostProcess:
         if fwhm <= 0:
             fwhm = 2 * np.sqrt(2 * np.log(2)) * np.std(rays)
         return fwhm
+
+    def _extract_divergence_fwhm(self, direction_component: np.array, dz_component: np.array):
+        with np.errstate(divide="ignore", invalid="ignore"):
+            divergence = np.degrees(np.arctan(direction_component / dz_component))
+        divergence = divergence[np.isfinite(divergence)]
+        if divergence.size == 0:
+            return np.nan
+        return self._extract_fwhm(divergence)
 
     def _extract_intensity(self, rays: np.array):
         """calculate how many rays there are
@@ -330,6 +340,16 @@ class PostProcess:
                 ray_properties.df.loc[0, "VerticalFocusFWHM"] = self._extract_fwhm(
                     rays[f"{exported_element}_OY"]
                 )
+                ray_properties.df.loc[0, "HorizontalDivergenceFWHM"] = (
+                    self._extract_divergence_fwhm(
+                        rays[f"{exported_element}_DX"], rays[f"{exported_element}_DZ"]
+                    )
+                )
+                ray_properties.df.loc[0, "VerticalDivergenceFWHM"] = (
+                    self._extract_divergence_fwhm(
+                        rays[f"{exported_element}_DY"], rays[f"{exported_element}_DZ"]
+                    )
+                )
                 ray_properties.df.loc[0, "HorizontalCenter"] = np.mean(
                     rays[f"{exported_element}_OX"]
                 )
@@ -400,6 +420,8 @@ class PostProcess:
             ray_properties.df.loc[0, "Bandwidth"] = np.nan
             ray_properties.df.loc[0, "HorizontalFocusFWHM"] = np.nan
             ray_properties.df.loc[0, "VerticalFocusFWHM"] = np.nan
+            ray_properties.df.loc[0, "HorizontalDivergenceFWHM"] = np.nan
+            ray_properties.df.loc[0, "VerticalDivergenceFWHM"] = np.nan
             ray_properties.df.loc[0, "HorizontalCenter"] = np.nan
             ray_properties.df.loc[0, "VerticalCenter"] = np.nan
             if undulator_table is None:

--- a/src/raypyng/simulate.py
+++ b/src/raypyng/simulate.py
@@ -1,5 +1,6 @@
 import csv
 import itertools
+import json
 import logging
 import os
 import re
@@ -1076,6 +1077,7 @@ class Simulate:
             if self.analyze is False and self.raypyng_analysis is True:
                 self.logger.info("Create Pandas Recap Files")
                 self._create_results_dataframe(self._exported_file_type)
+            self._write_analysis_metadata_file()
         if remove_round_folders:
             self._remove_round_folders()
         self.logger.info("End of the Simulations")
@@ -1138,6 +1140,74 @@ class Simulate:
                 res_combined = pd.concat([looper, res], axis=1)
                 res_combined = res_combined.loc[:, ~res_combined.columns.str.contains("^Unnamed")]
                 res_combined.to_csv(os.path.join(self.sim_path, f"{export}_{in_out}.csv"))
+
+    def _unit_for_output_column(self, column_name):
+        analysis_units = {
+            "Simulation Number": "index",
+            "SourcePhotonFlux": "photons/s",
+            "SourceBandwidth": "eV",
+            "NumberRaysSurvived": "count",
+            "PercentageRaysSurvived": "%",
+            "PhotonEnergy": "eV",
+            "Bandwidth": "eV",
+            "HorizontalFocusFWHM": "mm",
+            "VerticalFocusFWHM": "mm",
+            "HorizontalDivergenceFWHM": "deg",
+            "VerticalDivergenceFWHM": "deg",
+            "HorizontalCenter": "mm",
+            "VerticalCenter": "mm",
+            "PhotonFlux": "photons/s",
+            "EnergyPerMilPerBw": None,
+            "FluxPerMilPerBwPerc": None,
+            "FluxPerMilPerBwAbs": None,
+            "AXUVCurrentAmp": "A",
+            "GaAsPCurrentAmp": "A",
+        }
+        parameter_units = {
+            "photonEnergy": "eV",
+            "numberRays": "count",
+            "totalHeight": "mm",
+            "cFactor": None,
+        }
+
+        if column_name.startswith("Unnamed:"):
+            return None
+        if column_name in analysis_units:
+            return analysis_units[column_name]
+        if "." in column_name:
+            param_id = column_name.split(".")[-1]
+            return parameter_units.get(param_id)
+        return None
+
+    def _write_analysis_metadata_file(self):
+        sample_columns = None
+        for export in self._exported_obj_names_list:
+            for in_out in self._exported_file_type:
+                output_path = os.path.join(self.sim_path, f"{export}_{in_out}.csv")
+                if os.path.exists(output_path):
+                    sample_columns = list(pd.read_csv(output_path, nrows=0).columns)
+                    break
+            if sample_columns is not None:
+                break
+
+        if sample_columns is None:
+            return
+
+        first_analysis_column = "SourcePhotonFlux"
+        if first_analysis_column in sample_columns:
+            sample_columns = sample_columns[sample_columns.index(first_analysis_column) :]
+
+        metadata = {
+            "applies_to": "all raypyng analysis output files in this folder",
+            "columns": [
+                {"name": column_name, "unit": self._unit_for_output_column(column_name)}
+                for column_name in sample_columns
+            ],
+        }
+
+        metadata_path = os.path.join(self.sim_path, "raypyng_analysis_metadata.json")
+        with open(metadata_path, "w", encoding="utf-8") as metadata_file:
+            json.dump(metadata, metadata_file, indent=2)
 
     def _remove_recap_files(
         self,


### PR DESCRIPTION
## Summary

This PR extends raypyng analysis outputs with beam divergence metrics and adds a shared metadata sidecar describing output column units.

## What Changed

- added `HorizontalDivergenceFWHM` and `VerticalDivergenceFWHM` to analyzed ray outputs
- computed divergence from ray direction components using `atan(DX / DZ)` and `atan(DY / DZ)`
- exported divergence in degrees
- added one shared `raypyng_analysis_metadata.json` file per simulation folder
- limited the metadata sidecar to analyzed-output columns only, starting at `SourcePhotonFlux`
- kept recap CSV headers unchanged so existing downstream scripts continue to work

## Impact

Users now get divergence directly in the individual analyzed `.dat` files and in the combined recap CSVs, plus a single machine-readable units file for the analysis outputs.

## Validation

Validated through user-supervised example runs and local syntax checks with `python3 -m py_compile`.
