### PR TITLE
[codex] Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.4.0] - 16-April-2026
+
+### Added
+- Add `HorizontalDivergenceFWHM` and `VerticalDivergenceFWHM` to raypyng-analyzed outputs, computed from the ray direction vectors and exported in degrees.
+- Add a shared `raypyng_analysis_metadata.json` sidecar file with the units of the analyzed output columns.
+- Add `multiprocessing="auto"` and `multiprocessing="max"` modes to `Simulate.run()`.
+
+### Changed
+- Update examples to use `multiprocessing="auto"` instead of hardcoded worker counts.
+- Update tutorial and how-to documentation to reflect the current simulation output structure, analyzed files, recap files, metadata sidecar, and multiprocessing options.
+- Clean up several example scripts and fix stale file references and misleading comments.
+
+### Fixed
+- Fix a severe multiprocessing shutdown bug where simulations could finish writing outputs but the Python process could still hang during executor teardown.
+- Prevent recursive retry of missing simulations while a previous `ProcessPoolExecutor` is still active.
+- Handle unfinished futures more safely during shutdown, avoiding blocking exit when output files are already present.
+- Fix postprocessing aggregation across repeated rounds by matching analyzed files by simulation index instead of file order.
+- Ignore stale out-of-range analyzed files from previous runs during recap aggregation and final output checks.
+- Reduce child-process cleanup output to a single terminal message instead of one line per PID.
+
 ## [1.3.53] - 26-January-2026
 
 ### Added
@@ -146,7 +166,6 @@ All notable changes to this project will be documented in this file.
  
 ### Fixed
 - issue [#29](https://github.com/hz-b/raypyng/issues/29), Simulate.params used to throw an error when attempting list step-wise operation.
-
 
 
 

--- a/docs/API.rst
+++ b/docs/API.rst
@@ -26,12 +26,16 @@ stored and provides a simple way to get a list of absolute paths to the simulati
 VLS Grating Coefficient Calculation
 ====================================
 
-This function calculates the VLS grating coefficients (B₂–B₅) for a plane
-variable line spacing grating, given grazing incidence and diffraction angles,
-central groove density, photon energy, and source/image distances.
+This is a set of helper functions that can be used to calculate VLS gratings.
 
 .. autofunction:: raypyng.vls_grating.calculate_vls_coeff
-    
+
+
+.. autofunction:: raypyng.vls_grating.N1_to_b2
+
+.. autofunction:: raypyng.vls_grating.cff_for_fixed_focus
+
+
 Recipes
 ==================
 

--- a/docs/how_to.rst
+++ b/docs/how_to.rst
@@ -160,7 +160,7 @@ file for each element present in the beamline automatically.
         myRecipe = ExportEachElement(energy=1000,nrays=10000,sim_folder='MyRecipeTest')
 
         # test resolving power simulations
-        sim.run(myRecipe, multiprocessing=5, force=True)
+        sim.run(myRecipe, multiprocessing="auto", force=True)
 
 How to work with Undulator File
 ================================

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -317,9 +317,15 @@ Finally, the simulations can be run using
 
 .. code-block:: python
 
-    sim.run(multiprocessing=5, force=True)
+    sim.run(multiprocessing="auto", force=True)
 
-where the `multiprocessing` parameter can be an integer greater or equal to 1, corresponding to the number of parallel instances of RAY-UI to be used. Generally speaking, the number of instances of RAY-UI must be lower or equal than the number of available cores. If the simulation uses many rays, monitor the RAM usage of your computer. If the computation uses all the possible RAM of the computer the program may get blocked or not execute correctly.
+where the `multiprocessing` parameter can be:
+
+- an integer greater or equal to 1, corresponding to the number of parallel instances of RAY-UI to be used
+- `"auto"`, which uses the minimum between the available CPU count and the available RAM in GB minus 2
+- `"max"`, which uses the minimum between the available CPU count and the available RAM in GB
+
+Generally speaking, the number of instances of RAY-UI must be lower or equal than the number of available cores. If the simulation uses many rays, monitor the RAM usage of your computer. If the computation uses all the possible RAM of the computer the program may get blocked or not execute correctly.
 
 Note on multiprocessing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -342,24 +348,23 @@ Expect this folders and subfolders to be created:
 
 ::
 
-    RAYPy_simulation_mySimulation
-    ├── round_0          
-    │   ├── 0_*.rml
-    │   └── 0_*.csv
-    │   └── 0_*.dat (only if raypyng analyzes the results)
+    RAYPy_Simulation_mySimulation
+    ├── looper.csv
+    ├── looper.txt
+    ├── Dipole_RawRaysOutgoing.csv                    (if raypyng analyzes the results)
+    ├── DetectorAtFocus_RawRaysOutgoing.csv           (if raypyng analyzes the results)
+    ├── raypyng_analysis_metadata.json                (if raypyng analyzes the results)
+    ├── round_0
+    │   ├── 0_mySimulation.rml
+    │   ├── 0_Dipole-RawRaysOutgoing.csv
+    │   ├── 0_Dipole_analyzed_rays_RawRaysOutgoing.dat        (if raypyng analyzes the results)
+    │   ├── 0_DetectorAtFocus-RawRaysOutgoing.csv
+    │   ├── 0_DetectorAtFocus_analyzed_rays_RawRaysOutgoing.dat (if raypyng analyzes the results)
     │   └── ...
-    │   └── looper.py
-    ...
-    ├── round_n          
-    │   ├── 0_*.rml
-    │   └── 0_*.csv
-    │   └── 0_*.dat (only if raypyng analyzes the results)
+    ├── round_1
     │   └── ...
-    │   └── looper.py
-    ├── input_param_1.dat
-    ...
-    ├── input_param_k.dat
-    ├── output_simulation.dat (only if raypyng analyzes the results)
+    └── round_n
+        └── ...
 
 
 
@@ -370,9 +375,6 @@ Analysis performed by RAY-UI
 If you decided to let RAY-UI do the analysis, you should expect the following files to be 
 saved in your simulation folder:
 
-- one file for each parameter you set with the values that you passed to the program. 
-  If for instance, you input the Dipole numberRays, you will find a file called 
-  `input_param_Dipole_numberRays.dat`
 - one folder called `round_n` for each repetition of the simulations. 
   For instance, if you set :code:`sim.repeat=2` you will have two folders `round_0` and `round_1`
 - inside each `round_n` folder you will find the beamline files modified 
@@ -388,9 +390,7 @@ Analysis performed by raypyng
 If you decided to let raypyng do the analysis, you should expect the following files to 
 be saved in your simulation folder:
 
-- one file for each parameter you set with the values that you passed to the program. 
-  If for instance, you input the Dipole numberRays, you will find a file called 
-  `input_param_Dipole_numberRays.dat`
+- `looper.csv` and `looper.txt`, containing the simulation number and the scanned input parameters
 - one folder called `round_n` for each repetition of the simulations. 
   For instance, if you set :code:`sim.repeat=2` you will have two folders `round_0` and `round_1`
 - inside each `round_n` folder you will find the beamline files modified with the parameters 
@@ -399,26 +399,49 @@ be saved in your simulation folder:
   If for instance, you exported the `RawRaysOutgoing` of the Dipole, you will 
   have a list of files `0_Dipole-RawRaysOutgoing.csv`
 - for each `RawRaysOutgoing` file, raypyng calculates some properties, 
-  and saves a corresponding file, for instance `0_Dipole_analyzed_rays.dat`. 
-- In the simulation folder, all the for each exported element 
-  is brought together (and averaged in case of more rounds of simulations ) 
-  in one single file. For the dipole, the file is called `Dipole_RawRaysOutgoing.csv`. 
-  It contains the following columns, beside the input parameters:
+  and saves a corresponding file, for instance `0_Dipole_analyzed_rays_RawRaysOutgoing.dat`
+- in the simulation folder, the analyzed results for each exported element are brought together
+  (and averaged in case of more rounds of simulations) in one single file.
+  For the dipole, the file is called `Dipole_RawRaysOutgoing.csv`
+- one shared metadata sidecar, `raypyng_analysis_metadata.json`, describing the units of the
+  analyzed output columns. This metadata file is written only if :code:`sim.raypyng_analysis=True`
 
-    - Simulation Number  
-    - SourcePhotonFlux  
-    - NumberRaysSurvived  
-    - PercentageRaysSurvived  
-    - PhotonEnergy  
-    - Bandwidth  
-    - HorizontalFocusFWHM  
-    - VerticalFocusFWHM  
-    - PhotonFlux  
-    - EnergyPerMilPerBw  
-    - FluxPerMilPerBwPerc  
-    - FluxPerMilPerBwAbs  
-    - AXUVCurrentAmp  
-    - GaAsPCurrentAmp  
+The combined recap files contain the scanned input parameters from `looper.csv`,
+followed by the analyzed output columns. The analyzed columns currently include:
+
+- `SourcePhotonFlux` (`photons/s`)
+- `SourceBandwidth` (`eV`)
+- `NumberRaysSurvived` (`count`)
+- `PercentageRaysSurvived` (`%`)
+- `PhotonEnergy` (`eV`)
+- `Bandwidth` (`eV`)
+- `HorizontalFocusFWHM` (`mm`)
+- `VerticalFocusFWHM` (`mm`)
+- `HorizontalDivergenceFWHM` (`deg`)
+- `VerticalDivergenceFWHM` (`deg`)
+- `HorizontalCenter` (`mm`)
+- `VerticalCenter` (`mm`)
+- `PhotonFlux` (`photons/s`)
+- `EnergyPerMilPerBw` (dimensionless)
+- `FluxPerMilPerBwPerc` (dimensionless)
+- `FluxPerMilPerBwAbs` (dimensionless)
+- `AXUVCurrentAmp` (`A`)
+- `GaAsPCurrentAmp` (`A`)
+
+Shared metadata sidecar
+^^^^^^^^^^^^^^^^^^^^^^^^
+When raypyng performs the analysis, it also writes one metadata file in the simulation folder:
+
+- `raypyng_analysis_metadata.json`
+
+This file:
+
+- applies to all raypyng-analyzed output CSV files in the same simulation folder
+- lists only the analyzed-output columns, starting at `SourcePhotonFlux`
+- stores a column-to-unit mapping without modifying the CSV headers
+
+This keeps existing scripts based on exact CSV column names compatible, while still making the
+units available in a machine-readable format.
 
 Recipes
 ========

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -337,6 +337,7 @@ The speed increase due to opening many RAY-UI instances is effective only when R
 
 
 There is little/no difference having RayPyNG analyzing the results
+
 .. code-block:: python
 
     sim.raypyng_analysis=True # let raypyng analyze the results

--- a/examples/example_beamwaist.py
+++ b/examples/example_beamwaist.py
@@ -1,6 +1,5 @@
 from raypyng.simulate import Simulate
 from raypyng.beamwaist import PlotBeamwaist 
-from raypyng.recipes import BeamWaist
 import os
 
 
@@ -37,5 +36,4 @@ xh,yh,x,y=bw.plot(save_img=True,img_name='high_energy_branch',extension='.png',s
 
 # one can use xh,yh,x,y to buld his own plots:
 # suggested usage: ax.pcolormesh(x,y,np.log(self.xh), cmap='inferno')
-
 

--- a/examples/example_rml.py
+++ b/examples/example_rml.py
@@ -29,6 +29,6 @@ rml.beamline.Dipole.photonEnergy.cdata = str(2000)
 print('New Dipole photon energy: ',rml.beamline.Dipole.photonEnergy.cdata)
 
 # Save the rml file with a new name
-rml.write('rml/new_elisa.rml')
+rml.write('rml/new_dipole_beamline.rml')
 
         

--- a/examples/example_runner.py
+++ b/examples/example_runner.py
@@ -15,7 +15,7 @@ print("RAY-UI is running with pid", r.pid)
 
 # load an rml file
 print("Loading rml file")
-a.load('rml/elisa.rml')
+a.load('rml/dipole_beamline.rml')
 
 print("Trace...")
 a.trace(analyze=True)

--- a/examples/example_waveHelper.py
+++ b/examples/example_waveHelper.py
@@ -7,9 +7,8 @@ WH = WaveHelper('WAVE', 3, 'U49')
 WH.report_available_energies(verbose=True)
 
 energies = np.arange(80,570,10)
-matchin_en_list = WH.convert_energies_to_file_list(1,energies)
+matching_en_list = WH.convert_energies_to_file_list(1,energies)
 
-for ind, en in enumerate(matchin_en_list):
-    print(f"Energy: {en}, filename:{matchin_en_list[ind]}")
-
+for energy_file in matching_en_list:
+    print(f"filename: {energy_file}")
 

--- a/examples/simulation_analysis_by_RAY-UI.py
+++ b/examples/simulation_analysis_by_RAY-UI.py
@@ -44,7 +44,7 @@ sim.exports  =  [{beamline.Dipole:['ScalarElementProperties']},
 
 
 #uncomment to run the simulations
-sim.run(multiprocessing=5, force=True)
+sim.run(multiprocessing="auto", force=True)
 
 
 

--- a/examples/simulation_analysis_by_RAY-UI.py
+++ b/examples/simulation_analysis_by_RAY-UI.py
@@ -43,7 +43,6 @@ sim.exports  =  [{beamline.Dipole:['ScalarElementProperties']},
                 ]
 
 
-#uncomment to run the simulations
 sim.run(multiprocessing="auto", force=True)
 
 

--- a/examples/simulation_external_undulator_flux_table.py
+++ b/examples/simulation_external_undulator_flux_table.py
@@ -57,6 +57,5 @@ undulator = pd.read_csv(undulator_file_path)
 sim.undulator_table=undulator
 
 #uncomment to run the simulations
-sim.run(multiprocessing=6, force=True)
-
+sim.run(multiprocessing="auto", force=True)
 

--- a/examples/simulation_external_undulator_flux_table.py
+++ b/examples/simulation_external_undulator_flux_table.py
@@ -35,7 +35,7 @@ params = [
 sim.params=params
 
 # sim.simulation_folder = '/home/simone/Documents/RAYPYNG/raypyng/test'
-sim.simulation_name = 'test_noAnalyze_undulator'
+sim.simulation_name = 'external_undulator_flux_table'
 
 # repeat the simulations as many time as needed
 sim.repeat = 2
@@ -56,6 +56,4 @@ undulator = pd.read_csv(undulator_file_path)
 
 sim.undulator_table=undulator
 
-#uncomment to run the simulations
 sim.run(multiprocessing="auto", force=True)
-

--- a/examples/simulation_multilayer_monochromator_efficiency.py
+++ b/examples/simulation_multilayer_monochromator_efficiency.py
@@ -57,7 +57,12 @@ eff = pd.DataFrame({
 sim.efficiency = eff
 
 #uncomment to run the simulations
-sim.run(multiprocessing=5, force=True, remove_rawrays=True, remove_round_folders=True)
+sim.run(
+    multiprocessing="auto",
+    force=True,
+    remove_rawrays=True,
+    remove_round_folders=True,
+)
 
 
 

--- a/examples/simulation_multilayer_monochromator_efficiency.py
+++ b/examples/simulation_multilayer_monochromator_efficiency.py
@@ -56,7 +56,6 @@ eff = pd.DataFrame({
 # calculated by the RAY-UI
 sim.efficiency = eff
 
-#uncomment to run the simulations
 sim.run(
     multiprocessing="auto",
     force=True,

--- a/examples/simulation_permil.py
+++ b/examples/simulation_permil.py
@@ -49,7 +49,7 @@ sim.exports  =  [{beamline.Dipole:['RawRaysOutgoing']},
                 ]
 
 #uncomment to run the simulations
-sim.run(multiprocessing=8, force=True)
+sim.run(multiprocessing="auto", force=True)
 
 
 

--- a/examples/simulation_permil.py
+++ b/examples/simulation_permil.py
@@ -48,7 +48,6 @@ sim.exports  =  [{beamline.Dipole:['RawRaysOutgoing']},
                 {beamline.DetectorAtFocus:['RawRaysOutgoing']}
                 ]
 
-#uncomment to run the simulations
 sim.run(multiprocessing="auto", force=True)
 
 

--- a/examples/simulation_raypyng.py
+++ b/examples/simulation_raypyng.py
@@ -47,7 +47,7 @@ sim.exports  =  [{beamline.Dipole:['RawRaysOutgoing']},
                 ]
 
 #uncomment to run the simulations
-sim.run(multiprocessing=5, force=True, remove_rawrays=True)
+sim.run(multiprocessing="auto", force=True, remove_rawrays=True)
 
 
 

--- a/examples/simulation_raypyng.py
+++ b/examples/simulation_raypyng.py
@@ -46,7 +46,6 @@ sim.exports  =  [{beamline.Dipole:['RawRaysOutgoing']},
                 {beamline.DetectorAtFocus:['RawRaysOutgoing']}
                 ]
 
-#uncomment to run the simulations
 sim.run(multiprocessing="auto", force=True, remove_rawrays=True)
 
 

--- a/examples/simulation_recipee_Flux.py
+++ b/examples/simulation_recipee_Flux.py
@@ -22,7 +22,7 @@ sim.analyze = True
 #sim.params,sim.exports, sim.simulation_name = ResolvingPower(energy_range, beamline.DetectorAtFocus,ES,cff)
 flux = Flux(energy_range, [beamline.Dipole, beamline.DetectorAtFocus],ES,cff)
 
-# test resolving power simulations
+# test flux simulations
 sim.run(flux, multiprocessing="auto", force=True)
 
 

--- a/examples/simulation_recipee_Flux.py
+++ b/examples/simulation_recipee_Flux.py
@@ -23,7 +23,7 @@ sim.analyze = True
 flux = Flux(energy_range, [beamline.Dipole, beamline.DetectorAtFocus],ES,cff)
 
 # test resolving power simulations
-sim.run(flux, multiprocessing=5, force=True)
+sim.run(flux, multiprocessing="auto", force=True)
 
 
         

--- a/examples/simulation_recipee_ResolvinPower.py
+++ b/examples/simulation_recipee_ResolvinPower.py
@@ -23,7 +23,7 @@ sim.analyze = False
 rp = ResolvingPower(energy_range, [beamline.Dipole, beamline.DetectorAtFocus],ES,cff)
 
 # test resolving power simulations
-sim.run(rp, multiprocessing=5, force=True)
+sim.run(rp, multiprocessing="auto", force=True)
 
 
         

--- a/examples/simulation_recipee_ResolvinPower.py
+++ b/examples/simulation_recipee_ResolvinPower.py
@@ -22,7 +22,6 @@ sim.analyze = False
 #sim.params,sim.exports, sim.simulation_name = ResolvingPower(energy_range, beamline.DetectorAtFocus,ES,cff)
 rp = ResolvingPower(energy_range, [beamline.Dipole, beamline.DetectorAtFocus],ES,cff)
 
-# test resolving power simulations
 sim.run(rp, multiprocessing="auto", force=True)
 
 

--- a/examples/simulation_save_space.py
+++ b/examples/simulation_save_space.py
@@ -13,7 +13,7 @@ beamline = sim.rml.beamline
 
 
 # define the values of the parameters to scan 
-energy    = np.arange(200, 7201,250)
+energy    = np.arange(200, 7201,1)
 SlitSize  = np.array([0.1])
 cff       = np.array([2.25, 3])
 nrays     = 5e3
@@ -47,7 +47,7 @@ sim.exports  =  [{beamline.Dipole:['RawRaysOutgoing']},
                 ]
 
 #uncomment to run the simulations
-sim.run(multiprocessing=5, force=True, remove_rawrays=True, remove_round_folders=True)
+sim.run(multiprocessing=30, force=True, remove_rawrays=True, remove_round_folders=True)
 
 
 

--- a/examples/simulation_save_space.py
+++ b/examples/simulation_save_space.py
@@ -47,7 +47,12 @@ sim.exports  =  [{beamline.Dipole:['RawRaysOutgoing']},
                 ]
 
 #uncomment to run the simulations
-sim.run(multiprocessing=30, force=True, remove_rawrays=True, remove_round_folders=True)
+sim.run(
+    multiprocessing="auto",
+    force=True,
+    remove_rawrays=True,
+    remove_round_folders=True,
+)
 
 
 

--- a/examples/simulation_save_space.py
+++ b/examples/simulation_save_space.py
@@ -46,7 +46,6 @@ sim.exports  =  [{beamline.Dipole:['RawRaysOutgoing']},
                 {beamline.DetectorAtFocus:['RawRaysOutgoing']},
                 ]
 
-#uncomment to run the simulations
 sim.run(
     multiprocessing="auto",
     force=True,

--- a/examples/simulation_save_space.py
+++ b/examples/simulation_save_space.py
@@ -13,7 +13,7 @@ beamline = sim.rml.beamline
 
 
 # define the values of the parameters to scan 
-energy    = np.arange(200, 7201,1)
+energy    = np.arange(200, 7201,15)
 SlitSize  = np.array([0.1])
 cff       = np.array([2.25, 3])
 nrays     = 5e3

--- a/examples/simulation_slope_errors.py
+++ b/examples/simulation_slope_errors.py
@@ -61,4 +61,9 @@ sim.raypyng_analysis = True # let RAY-UI analyze the results
 sim.exports  =  [{beamline.DetectorAtFocus:['RawRaysOutgoing']}]
 
 #uncomment to run the simulations
-sim.run(multiprocessing=5, force=False, remove_round_folders=False, remove_rawrays=False)
+sim.run(
+    multiprocessing="auto",
+    force=False,
+    remove_round_folders=False,
+    remove_rawrays=False,
+)

--- a/examples/simulation_slope_errors.py
+++ b/examples/simulation_slope_errors.py
@@ -4,8 +4,6 @@ from raypyng import Simulate
 # define the values of the parameters to scan 
 def make_slopes_params(param_dict):
     # Start with the number of parameters
-    expanded_entries = []
-
     # First entry is the all-zero base
     total_steps = 1 + sum(len(v) for v in param_dict.values())
 
@@ -55,12 +53,11 @@ sim.simulation_name = 'SlopeErrors'
 # repeat the simulations as many time as needed
 sim.repeat = rounds
 
-sim.analyze = False # let RAY-UI analyze the results
-sim.raypyng_analysis = True # let RAY-UI analyze the results
+sim.analyze = False # don't let RAY-UI analyze the results
+sim.raypyng_analysis = True # let raypyng analyze the results
 ## This must be a list of dictionaries
 sim.exports  =  [{beamline.DetectorAtFocus:['RawRaysOutgoing']}]
 
-#uncomment to run the simulations
 sim.run(
     multiprocessing="auto",
     force=False,

--- a/examples/simulation_waveFiles.py
+++ b/examples/simulation_waveFiles.py
@@ -53,6 +53,4 @@ sim.exports  =  [{beamline.Undulator:['RawRaysOutgoing']},
                 {beamline.DetectorAtFocus:['RawRaysOutgoing']}
                 ]
 
-#uncomment to run the simulations
 sim.run(multiprocessing="auto", force=True)
-

--- a/examples/simulation_waveFiles.py
+++ b/examples/simulation_waveFiles.py
@@ -54,6 +54,5 @@ sim.exports  =  [{beamline.Undulator:['RawRaysOutgoing']},
                 ]
 
 #uncomment to run the simulations
-sim.run(multiprocessing=5, force=True)
-
+sim.run(multiprocessing="auto", force=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raypyng"
-version = "1.3.53"
+version = "1.4.0"
 
 authors = [
   { name = "Simone Vadilonga, Ruslan Ovsyannikov, Sebastian Sachse", email = "simone.vadilonga@helmholtz-berlin.de" },

--- a/src/raypyng/postprocessing.py
+++ b/src/raypyng/postprocessing.py
@@ -21,6 +21,8 @@ class RayProperties:
             "Bandwidth",
             "HorizontalFocusFWHM",
             "VerticalFocusFWHM",
+            "HorizontalDivergenceFWHM",
+            "VerticalDivergenceFWHM",
             "HorizontalCenter",
             "VerticalCenter",
         ]
@@ -153,6 +155,14 @@ class PostProcess:
         if fwhm <= 0:
             fwhm = 2 * np.sqrt(2 * np.log(2)) * np.std(rays)
         return fwhm
+
+    def _extract_divergence_fwhm(self, direction_component: np.array, dz_component: np.array):
+        with np.errstate(divide="ignore", invalid="ignore"):
+            divergence = np.degrees(np.arctan(direction_component / dz_component))
+        divergence = divergence[np.isfinite(divergence)]
+        if divergence.size == 0:
+            return np.nan
+        return self._extract_fwhm(divergence)
 
     def _extract_intensity(self, rays: np.array):
         """calculate how many rays there are
@@ -330,6 +340,16 @@ class PostProcess:
                 ray_properties.df.loc[0, "VerticalFocusFWHM"] = self._extract_fwhm(
                     rays[f"{exported_element}_OY"]
                 )
+                ray_properties.df.loc[0, "HorizontalDivergenceFWHM"] = (
+                    self._extract_divergence_fwhm(
+                        rays[f"{exported_element}_DX"], rays[f"{exported_element}_DZ"]
+                    )
+                )
+                ray_properties.df.loc[0, "VerticalDivergenceFWHM"] = (
+                    self._extract_divergence_fwhm(
+                        rays[f"{exported_element}_DY"], rays[f"{exported_element}_DZ"]
+                    )
+                )
                 ray_properties.df.loc[0, "HorizontalCenter"] = np.mean(
                     rays[f"{exported_element}_OX"]
                 )
@@ -400,6 +420,8 @@ class PostProcess:
             ray_properties.df.loc[0, "Bandwidth"] = np.nan
             ray_properties.df.loc[0, "HorizontalFocusFWHM"] = np.nan
             ray_properties.df.loc[0, "VerticalFocusFWHM"] = np.nan
+            ray_properties.df.loc[0, "HorizontalDivergenceFWHM"] = np.nan
+            ray_properties.df.loc[0, "VerticalDivergenceFWHM"] = np.nan
             ray_properties.df.loc[0, "HorizontalCenter"] = np.nan
             ray_properties.df.loc[0, "VerticalCenter"] = np.nan
             if undulator_table is None:

--- a/src/raypyng/postprocessing.py
+++ b/src/raypyng/postprocessing.py
@@ -109,6 +109,11 @@ class PostProcess:
         # Assuming natsorted and ns are properly imported and available in the context
         return natsorted(res, alg=ns.IGNORECASE)
 
+    def _extract_sim_index(self, filepath: str):
+        filename = os.path.basename(filepath)
+        sim_index = filename.split("_", 1)[0]
+        return int(sim_index) if sim_index.isdigit() else None
+
     def _extract_fwhm(self, rays: np.array):
         """Calculate the fwhm of the rays.
 
@@ -499,25 +504,48 @@ class PostProcess:
             repeat (int, optional): number of rounds of simulations. Defaults to 1.
             exp_elements (list, optional): the exported elements names as str. Defaults to None.
         """
+        expected_simulations = len(
+            {
+                self._extract_sim_index(path)
+                for path in self._list_files(
+                    os.path.join(dir_path, "round_0"),
+                    contain_str=".rml",
+                )
+                if self._extract_sim_index(path) is not None
+            }
+        )
         for d in exp_elements:
             for exp in exported_file_type:
+                analyzed_rays = None
                 for round in range(repeat):
                     dir_path_round = os.path.join(dir_path, "round_" + str(round))
                     files = self._list_files(
                         dir_path_round, d + "_analyzed_rays_" + exp + self.format_saved_files
                     )
-                    for f_ind, f in enumerate(files):
-                        if round == 0 and f_ind == 0:  # first round, first file, create
-                            analyzed_rays = pd.read_csv(f)
-                        elif round == 0 and f_ind != 0:  # first round, following files, concatenate
-                            tmp = pd.read_csv(f)
-                            analyzed_rays = pd.concat([analyzed_rays, tmp], ignore_index=True)
-                        elif round >= 1:  # other rounds: sum the values
-                            tmp = pd.read_csv(f)
-                            for n in analyzed_rays.columns:
-                                if isinstance(tmp.loc[0, n], (int, float)):
-                                    analyzed_rays.loc[f_ind, n] += float(tmp.loc[0, n])
+                    for f in files:
+                        sim_index = self._extract_sim_index(f)
+                        if sim_index is None or sim_index >= expected_simulations:
+                            continue
+                        tmp = pd.read_csv(f)
+                        tmp["_sim_index"] = sim_index
+                        if round == 0 and analyzed_rays is None:
+                            analyzed_rays = tmp
+                            analyzed_rays.set_index("_sim_index", inplace=True)
+                        elif round == 0:
+                            tmp.set_index("_sim_index", inplace=True)
+                            analyzed_rays = pd.concat([analyzed_rays, tmp], axis=0)
+                        else:
+                            tmp.set_index("_sim_index", inplace=True)
+                            if sim_index not in analyzed_rays.index:
+                                analyzed_rays = pd.concat([analyzed_rays, tmp], axis=0)
+                            else:
+                                for n in analyzed_rays.columns:
+                                    if isinstance(tmp.iloc[0][n], (int, float)):
+                                        analyzed_rays.loc[sim_index, n] += float(tmp.iloc[0][n])
                         os.remove(f)
+
+                if analyzed_rays is None:
+                    continue
 
                 def divide_numeric_rows(row):
                     # Check if all elements in the row are of a numeric type
@@ -527,6 +555,7 @@ class PostProcess:
                         return row
 
                 analyzed_rays = analyzed_rays.apply(divide_numeric_rows, axis=1)
+                analyzed_rays = analyzed_rays.sort_index().reset_index(drop=True)
                 # Apply the function across the DataFrame
                 # save the file
                 fn = os.path.join(dir_path, d + "_" + exp + ".csv")

--- a/src/raypyng/runner.py
+++ b/src/raypyng/runner.py
@@ -4,6 +4,8 @@
 # from sre_constants import SUCCESS
 import atexit
 import os
+import select
+import signal
 import subprocess
 import time
 
@@ -72,12 +74,13 @@ class RayUIRunner:
         self._process = None
         self._verbose = False
         if hide:
-            self._hide = "xvfb-run --auto-servernum --server-num=3000 "
+            self._hide = ["xvfb-run", "--auto-servernum", "--server-num=3000"]
         else:
-            self._hide = ""
+            self._hide = []
 
         # internal configuration parameters
         self._auto_flush = True  # flush on write calls
+        self._stdout_buffer = bytearray()
 
     def run(self):
         """Open one instance of RAY-UI using subprocess
@@ -90,16 +93,20 @@ class RayUIRunner:
             fullpath = os.path.join(self._path, self._binary)
             if not os.path.isfile(fullpath):
                 raise RayPyRunnerError("Ray executable {0} is not found".format(fullpath))
-            fullpath = self._hide + fullpath
+            cmd = [*self._hide, fullpath]
+            if self._options:
+                cmd.append(self._options)
             env = dict(os.environ)  # TODO:: rethink a bit about this line
             self._process = subprocess.Popen(
-                fullpath + " -b",
-                shell=True,
+                cmd,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 env=env,
+                start_new_session=True,
             )
+            os.set_blocking(self._process.stdout.fileno(), False)
+            self._stdout_buffer.clear()
             atexit.register(self.kill)
         return self
 
@@ -113,22 +120,33 @@ class RayUIRunner:
         if self._process is None:
             return False
         else:
-            poll_result = self._process.poll()
-            if poll_result is not None:
-                # we have an exit code, so process is not valid any more and clean it it up
-                self._process = None
-                return False
-            else:
-                return True
+            return self._process.poll() is None
 
     def kill(self):
         """kill a RAY-UI process"""
+        if self._process is None:
+            return
+
         if self.isrunning:
             pid = self._process.pid
-            process = psutil.Process(pid)
-            for proc in process.children(recursive=True):
-                proc.kill()
-            process.kill()
+            try:
+                os.killpg(pid, signal.SIGTERM)
+                self._process.wait(timeout=5)
+            except (ProcessLookupError, subprocess.TimeoutExpired):
+                try:
+                    process = psutil.Process(pid)
+                    for proc in process.children(recursive=True):
+                        proc.kill()
+                    process.kill()
+                except psutil.NoSuchProcess:
+                    pass
+                try:
+                    os.killpg(pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+
+        self._close_pipes()
+        self._process = None
 
     @property
     def pid(self):
@@ -166,13 +184,65 @@ class RayUIRunner:
         Returns:
             str: line read from the input
         """
-        if self.isrunning:
-            line = self._process.stdout.readline().decode("utf8").rstrip("\n")
-            if self._verbose:  # verbose
-                print(line)
-            return line
-        else:
+        return self._readline_with_timeout(timeout=None)
+
+    def _readline_with_timeout(self, timeout=None) -> str:
+        """Read one line from stdout, optionally timing out if no new line arrives."""
+        if not self.isrunning:
             return None
+
+        deadline = None if timeout is None else time.monotonic() + timeout
+        stdout_fd = self._process.stdout.fileno()
+
+        while True:
+            newline_index = self._stdout_buffer.find(b"\n")
+            if newline_index != -1:
+                line = self._stdout_buffer[:newline_index]
+                del self._stdout_buffer[: newline_index + 1]
+                decoded_line = line.decode("utf8", errors="replace").rstrip("\r")
+                if self._verbose:
+                    print(decoded_line)
+                return decoded_line
+
+            if not self.isrunning:
+                if self._stdout_buffer:
+                    line = self._stdout_buffer.decode("utf8", errors="replace").rstrip("\r")
+                    self._stdout_buffer.clear()
+                    if self._verbose:
+                        print(line)
+                    return line
+                return None
+
+            wait_time = None
+            if deadline is not None:
+                wait_time = max(0.0, deadline - time.monotonic())
+                if wait_time == 0.0:
+                    return None
+
+            readable, _, _ = select.select([stdout_fd], [], [], wait_time)
+            if not readable:
+                return None
+
+            chunk = os.read(stdout_fd, 4096)
+            if not chunk:
+                if self._stdout_buffer:
+                    line = self._stdout_buffer.decode("utf8", errors="replace").rstrip("\r")
+                    self._stdout_buffer.clear()
+                    if self._verbose:
+                        print(line)
+                    return line
+                return None
+            self._stdout_buffer.extend(chunk)
+
+    def _close_pipes(self):
+        for stream_name in ("stdin", "stdout", "stderr"):
+            stream = getattr(self._process, stream_name, None)
+            if stream is not None:
+                try:
+                    stream.close()
+                except Exception:
+                    pass
+        self._stdout_buffer.clear()
 
     def __detect_ray_path(self) -> str:
         """Internal function to autodetect installation path of RAY-UI
@@ -309,10 +379,14 @@ class RayUIAPI:
         # and once as status return
         cmd_seen = False
         while True:
-            line = self._runner._readline()
+            poll_timeout = self._read_wait_delay if timeout is not None else None
+            line = self._runner._readline_with_timeout(timeout=poll_timeout)
             if line is None:
-                time.sleep(self._read_wait_delay)
+                if timeout is None:
+                    continue
                 timecnt += self._read_wait_delay
+                if timecnt > timeout:
+                    raise TimeoutError("timeout while waiting ray command io")
                 continue
             if line.startswith(cmd):
                 if cmd_seen:
@@ -322,6 +396,4 @@ class RayUIAPI:
             else:
                 if cbdataread is not None:
                     cbdataread(line)
-            if timeout is not None and timecnt > timeout:
-                raise TimeoutError("timeout while waiting ray command io")
         return line.lstrip(cmd).strip()

--- a/src/raypyng/simulate.py
+++ b/src/raypyng/simulate.py
@@ -1,5 +1,6 @@
 import csv
 import itertools
+import json
 import logging
 import os
 import re
@@ -1076,6 +1077,7 @@ class Simulate:
             if self.analyze is False and self.raypyng_analysis is True:
                 self.logger.info("Create Pandas Recap Files")
                 self._create_results_dataframe(self._exported_file_type)
+            self._write_analysis_metadata_file()
         if remove_round_folders:
             self._remove_round_folders()
         self.logger.info("End of the Simulations")
@@ -1138,6 +1140,74 @@ class Simulate:
                 res_combined = pd.concat([looper, res], axis=1)
                 res_combined = res_combined.loc[:, ~res_combined.columns.str.contains("^Unnamed")]
                 res_combined.to_csv(os.path.join(self.sim_path, f"{export}_{in_out}.csv"))
+
+    def _unit_for_output_column(self, column_name):
+        analysis_units = {
+            "Simulation Number": "index",
+            "SourcePhotonFlux": "photons/s",
+            "SourceBandwidth": "eV",
+            "NumberRaysSurvived": "count",
+            "PercentageRaysSurvived": "%",
+            "PhotonEnergy": "eV",
+            "Bandwidth": "eV",
+            "HorizontalFocusFWHM": "mm",
+            "VerticalFocusFWHM": "mm",
+            "HorizontalDivergenceFWHM": "deg",
+            "VerticalDivergenceFWHM": "deg",
+            "HorizontalCenter": "mm",
+            "VerticalCenter": "mm",
+            "PhotonFlux": "photons/s",
+            "EnergyPerMilPerBw": None,
+            "FluxPerMilPerBwPerc": None,
+            "FluxPerMilPerBwAbs": None,
+            "AXUVCurrentAmp": "A",
+            "GaAsPCurrentAmp": "A",
+        }
+        parameter_units = {
+            "photonEnergy": "eV",
+            "numberRays": "count",
+            "totalHeight": "mm",
+            "cFactor": None,
+        }
+
+        if column_name.startswith("Unnamed:"):
+            return None
+        if column_name in analysis_units:
+            return analysis_units[column_name]
+        if "." in column_name:
+            param_id = column_name.split(".")[-1]
+            return parameter_units.get(param_id)
+        return None
+
+    def _write_analysis_metadata_file(self):
+        sample_columns = None
+        for export in self._exported_obj_names_list:
+            for in_out in self._exported_file_type:
+                output_path = os.path.join(self.sim_path, f"{export}_{in_out}.csv")
+                if os.path.exists(output_path):
+                    sample_columns = list(pd.read_csv(output_path, nrows=0).columns)
+                    break
+            if sample_columns is not None:
+                break
+
+        if sample_columns is None:
+            return
+
+        first_analysis_column = "SourcePhotonFlux"
+        if first_analysis_column in sample_columns:
+            sample_columns = sample_columns[sample_columns.index(first_analysis_column) :]
+
+        metadata = {
+            "applies_to": "all raypyng analysis output files in this folder",
+            "columns": [
+                {"name": column_name, "unit": self._unit_for_output_column(column_name)}
+                for column_name in sample_columns
+            ],
+        }
+
+        metadata_path = os.path.join(self.sim_path, "raypyng_analysis_metadata.json")
+        with open(metadata_path, "w", encoding="utf-8") as metadata_file:
+            json.dump(metadata, metadata_file, indent=2)
 
     def _remove_recap_files(
         self,

--- a/src/raypyng/simulate.py
+++ b/src/raypyng/simulate.py
@@ -997,6 +997,29 @@ class Simulate:
         self.logger = logging.getLogger(__name__)
         self.logger.info(f"Simulation started, using {self._workers} workers")
 
+    def _resolve_multiprocessing_workers(self, multiprocessing):
+        if isinstance(multiprocessing, str):
+            mode = multiprocessing.lower()
+            if mode not in {"auto", "max"}:
+                raise ValueError(
+                    "The 'multiprocessing' argument must be an integer greater than 0, "
+                    "or one of: 'auto', 'max'."
+                )
+
+            cpu_count = os.cpu_count() or 1
+            available_ram_gb = max(1, int(psutil.virtual_memory().available / (1024**3)))
+
+            if mode == "auto":
+                return max(1, min(cpu_count, available_ram_gb - 2))
+            return max(1, min(cpu_count, available_ram_gb))
+
+        if not isinstance(multiprocessing, int) or multiprocessing < 1:
+            raise ValueError(
+                "The 'multiprocessing' argument must be an integer greater than 0, "
+                "or one of: 'auto', 'max'."
+            )
+        return multiprocessing
+
     def run(
         self,
         recipe=None,
@@ -1016,8 +1039,9 @@ class Simulate:
         Args:
             recipe (SimulationRecipe, optional): Recipe for simulation setup.
                                                     Defaults to None.
-            multiprocessing (int, optional): Number of processes for parallel execution.
-                                                    Defaults to 1.
+            multiprocessing (int or str, optional): Number of processes for parallel execution,
+                                                    or 'auto'/'max' to derive it from available
+                                                    CPUs and RAM. Defaults to 1.
             force (bool, optional): Force re-execution of simulations.
                                                     Defaults to False.
             overwrite_rml (bool, optional): Overwrite existing RML files. Defaults to True.
@@ -1028,8 +1052,7 @@ class Simulate:
             remove_round_folders (bool, optional): remove the round folders after the simulations
                                                     are done.
         """
-        if not isinstance(multiprocessing, int) or multiprocessing < 1:
-            raise ValueError("The 'multiprocessing' argument must be an integer greater than 0.")
+        multiprocessing = self._resolve_multiprocessing_workers(multiprocessing)
 
         if remove_rawrays and not self.raypyng_analysis:
             raise Exception(

--- a/src/raypyng/simulate.py
+++ b/src/raypyng/simulate.py
@@ -871,7 +871,7 @@ class Simulate:
             bool: True if the simulation is missing any export files, False otherwise.
         """
         round_folder = "round_" + str(repeat)
-        folder = os.path.join(self._sim_folder, round_folder)
+        folder = os.path.join(self.sim_path, round_folder)
         for export_config in self._exports_list:
             if self.raypyng_analysis:
                 export_file = os.path.join(
@@ -885,6 +885,48 @@ class Simulate:
                 return True  # Missing at least one export file
 
         return False
+
+    def _missing_simulations_for_round(self, round_number):
+        """Return missing simulation indices for a round using a single directory scan."""
+        round_folder = os.path.join(self.sim_path, "round_" + str(round_number))
+        expected_ids = set(range(self.sp._calc_number_sim()))
+
+        if self.raypyng_analysis:
+            expected_suffixes = [
+                f"_{export_config[0]}_analyzed_rays_{export_config[1]}.dat"
+                for export_config in self._exports_list
+            ]
+        else:
+            expected_suffixes = [
+                f"_{export_config[0]}-{export_config[1]}.csv" for export_config in self._exports_list
+            ]
+
+        found_per_export = {suffix: set() for suffix in expected_suffixes}
+        self.logger.info(f"Scanning round {round_number} outputs in {round_folder}")
+
+        with os.scandir(round_folder) as entries:
+            for entry in entries:
+                if not entry.is_file():
+                    continue
+                filename = entry.name
+                for suffix in expected_suffixes:
+                    if not filename.endswith(suffix):
+                        continue
+                    sim_index = filename[: -len(suffix)].split("_", 1)[0]
+                    if sim_index.isdigit():
+                        sim_index = int(sim_index)
+                        if sim_index in expected_ids:
+                            found_per_export[suffix].add(sim_index)
+                    break
+
+        completed_ids = expected_ids.copy()
+        for suffix, found_ids in found_per_export.items():
+            self.logger.info(
+                f"Round {round_number}: found {len(found_ids)}/{len(expected_ids)} files for {suffix}"
+            )
+            completed_ids &= found_ids
+
+        return sorted(expected_ids - completed_ids)
 
     def _make_exports_list(self, sim_number, round_n):
         exports_list = []
@@ -1005,15 +1047,22 @@ class Simulate:
         self._init_logging()
         total_simulations = self.sp._calc_number_sim() * self.repeat
         self.simulations_checked = False
+        self._executor_has_unfinished_futures = False
 
         pbar = self._initialize_progress_bar(total_simulations, description="Simulations Completed")
         try:
             self._execute_simulations(multiprocessing, force, total_simulations, pbar)
-            pbar.close()
             self.logger.info("Simulation completed successfully.")
         except KeyboardInterrupt:
             self.logger.error("Simulation Interrupted.", exc_info=True)
             self.cleanup_child_processes()
+            raise
+        except Exception:
+            self.logger.error("Simulation failed.", exc_info=True)
+            self.cleanup_child_processes()
+            raise
+        finally:
+            pbar.close()
         if self.raypyng_analysis:
             self.logger.info("Starting cleanup")
             pp = PostProcess()
@@ -1039,11 +1088,14 @@ class Simulate:
         and any specific Xvfb processes."""
         current_process = psutil.Process()
         children = current_process.children(recursive=True)
+        announced_cleanup = False
 
         # First, terminate general child processes
         for child in children:
             try:
-                print(f"Terminating child process {child.pid}")
+                if not announced_cleanup:
+                    print("Terminating child processes...")
+                    announced_cleanup = True
                 child.terminate()
                 child.wait(timeout=3)  # Give it some time to gracefully shut down
             except psutil.NoSuchProcess:
@@ -1129,53 +1181,72 @@ class Simulate:
         """
         simulations_durations = []  # Track durations of all simulations for average calculation
         executor = None
+        rerun_missing = False
+        rerun_pbar = None
 
         try:
-            with ProcessPoolExecutor(max_workers=multiprocessing) as executor:
-                simulation_params_batch = []
-                batch_length = 0
-                remaining_simulations = total_simulations
-                for round_number in range(self.repeat):
-                    self.logger.info(f"Start round {round_number}")
-                    for sim_number, params in enumerate(self.sp.simulation_parameters_generator()):
-                        if round_number == 0 and update_reacap_files is True:
-                            self._update_simulation_recap_files(params, sim_number)
-                        if self._is_simulation_missing(sim_number, round_number) or force:
-                            self._prepare_and_submit_simulation(
-                                params,
-                                sim_number,
-                                round_number,
-                                simulation_params_batch,
-                                executor,
-                                force,
-                            )
-                        else:
-                            pbar.update(1)  # If not missing or forced, update progress bar directly
-                        batch_length += 1
-                        remaining_simulations -= 1
-                        if batch_length == self.batch_size or remaining_simulations == 0:
-                            self._wait_for_simulation_batch(
-                                simulations_durations, simulation_params_batch, executor, pbar
-                            )
-                            self.logger.info(
-                                f"Waiting For batch, {self.batch_size} simulations to go"
-                            )
-                            batch_length = 0
-                        if remaining_simulations == 0:
-                            self.logger.info(
-                                f"Remaning Simulations {remaining_simulations}, \
-                                    stop the simulations loop"
-                            )
-                            self._final_check_on_simulations_and_shutdown(executor, pbar)
-                            break
+            executor = ProcessPoolExecutor(max_workers=multiprocessing)
+            simulation_params_batch = []
+            batch_length = 0
+            remaining_simulations = total_simulations
+            for round_number in range(self.repeat):
+                self.logger.info(f"Start round {round_number}")
+                for sim_number, params in enumerate(self.sp.simulation_parameters_generator()):
+                    if round_number == 0 and update_reacap_files is True:
+                        self._update_simulation_recap_files(params, sim_number)
+                    if self._is_simulation_missing(sim_number, round_number) or force:
+                        self._prepare_and_submit_simulation(
+                            params,
+                            sim_number,
+                            round_number,
+                            simulation_params_batch,
+                            executor,
+                            force,
+                        )
+                    else:
+                        pbar.update(1)  # If not missing or forced, update progress bar directly
+                    batch_length += 1
+                    remaining_simulations -= 1
+                    if batch_length == self.batch_size or remaining_simulations == 0:
+                        self._wait_for_simulation_batch(
+                            simulations_durations, simulation_params_batch, executor, pbar
+                        )
+                        self.logger.info(f"Waiting For batch, {self.batch_size} simulations to go")
+                        batch_length = 0
+                    if remaining_simulations == 0:
+                        self.logger.info(
+                            f"Remaning Simulations {remaining_simulations}, \
+                                stop the simulations loop"
+                        )
+                        rerun_missing, rerun_pbar = self._final_check_on_simulations_and_shutdown(
+                            pbar
+                        )
+                        break
         except Exception as e:
             traceback.print_exc()
             self.logger.info(f"Error in _execute simulations: {e}")
+            raise
+        finally:
             if executor is not None:
-                executor.shutdown(cancel_futures=True)
-                self.logger.info("Executor shutdown completed.")
+                shutdown_wait = not rerun_missing and not self._executor_has_unfinished_futures
+                force_cancel = rerun_missing or self._executor_has_unfinished_futures
+                executor.shutdown(wait=shutdown_wait, cancel_futures=force_cancel)
+                self.logger.info(
+                    "Executor shutdown completed%s.",
+                    " without waiting" if not shutdown_wait else "",
+                )
+                if force_cancel:
+                    self.cleanup_child_processes()
+        if rerun_missing:
+            self._execute_simulations(
+                self._workers,
+                False,
+                total_simulations,
+                rerun_pbar,
+                update_reacap_files=False,
+            )
 
-    def _final_check_on_simulations_and_shutdown(self, executor, old_pbar):
+    def _final_check_on_simulations_and_shutdown(self, old_pbar):
 
         # check that all simulatins are completed:
         self.logger.info(
@@ -1183,12 +1254,13 @@ class Simulate:
         )
         missing_sim = []
         for round_number in range(self.repeat):
-            for sim_number, _params in enumerate(self.sp.simulation_parameters_generator()):
-                if self._is_simulation_missing(sim_number, round_number):
-                    self.logger.info(
-                        f"This simulation is missing: round {round_number}, number {sim_number}"
-                    )
-                    missing_sim.append({"round": round_number, "sim_number": sim_number})
+            round_missing = self._missing_simulations_for_round(round_number)
+            self.logger.info(
+                f"Round {round_number}: final check found {len(round_missing)} missing simulations"
+            )
+            for sim_number in round_missing:
+                self.logger.info(f"This simulation is missing: round {round_number}, number {sim_number}")
+                missing_sim.append({"round": round_number, "sim_number": sim_number})
 
         if len(missing_sim) >= 1 and self.simulations_checked is False:
             self.logger.info("Finish missing simulations")
@@ -1198,9 +1270,9 @@ class Simulate:
                 total_simulations, description="Checking Simulations"
             )
             self.simulations_checked = True
-            self._execute_simulations(
-                self._workers, False, total_simulations, pbar, update_reacap_files=False
-            )
+            return True, pbar
+
+        return False, old_pbar
 
     def _prepare_and_submit_simulation(
         self, params, sim_number, round_number, simulation_params_batch, executor, force
@@ -1272,6 +1344,14 @@ class Simulate:
                 )
         except Exception as e:
             self.logger.info(f"Exception during simulation: {e}")
+            unfinished_futures = [future for future in futures if not future.done()]
+            if unfinished_futures:
+                self._executor_has_unfinished_futures = True
+                self.logger.info(
+                    f"Marking executor as having {len(unfinished_futures)} unfinished futures"
+                )
+                for future in unfinished_futures:
+                    future.cancel()
             try:
                 wait_time = self._simulation_timeout / 4
                 for sim in simulation_params_batch:

--- a/src/raypyng/simulate.py
+++ b/src/raypyng/simulate.py
@@ -960,7 +960,7 @@ class Simulate:
         multiprocessing=1,
         force=False,
         overwrite_rml=True,
-        force_exit=True,
+        force_exit=False,
         remove_rawrays=False,
         remove_round_folders=False,
     ):
@@ -978,8 +978,8 @@ class Simulate:
             force (bool, optional): Force re-execution of simulations.
                                                     Defaults to False.
             overwrite_rml (bool, optional): Overwrite existing RML files. Defaults to True.
-            force_exit (bool, optional): calls os.exit when the simulations are complete.
-                                            Nothing else will run after it. Defaults to True.
+            force_exit (bool, optional): emergency fallback that calls os._exit when the
+                                            simulations are complete. Defaults to False.
             remove_rawrays (bool, optional): removes RawRaysIncoming and RawRaysOutgoing files,
                                                 if present.
             remove_round_folders (bool, optional): remove the round folders after the simulations
@@ -1128,6 +1128,7 @@ class Simulate:
             pbar (tqdm): Progress bar object for tracking simulation progress.
         """
         simulations_durations = []  # Track durations of all simulations for average calculation
+        executor = None
 
         try:
             with ProcessPoolExecutor(max_workers=multiprocessing) as executor:
@@ -1166,13 +1167,13 @@ class Simulate:
                                     stop the simulations loop"
                             )
                             self._final_check_on_simulations_and_shutdown(executor, pbar)
-                            executor.shutdown(wait=False, cancel_futures=True)
                             break
         except Exception as e:
             traceback.print_exc()
             self.logger.info(f"Error in _execute simulations: {e}")
-            executor.shutdown(wait=False)
-            self.logger.info("Executor shutdown completed.")
+            if executor is not None:
+                executor.shutdown(cancel_futures=True)
+                self.logger.info("Executor shutdown completed.")
 
     def _final_check_on_simulations_and_shutdown(self, executor, old_pbar):
 
@@ -1188,9 +1189,6 @@ class Simulate:
                         f"This simulation is missing: round {round_number}, number {sim_number}"
                     )
                     missing_sim.append({"round": round_number, "sim_number": sim_number})
-
-        executor.shutdown(wait=False)
-        self.logger.info("Executor shutdown completed.")
 
         if len(missing_sim) >= 1 and self.simulations_checked is False:
             self.logger.info("Finish missing simulations")


### PR DESCRIPTION
## [1.4.0] - 16-April-2026

### Added
- Add `HorizontalDivergenceFWHM` and `VerticalDivergenceFWHM` to raypyng-analyzed outputs, computed from the ray direction vectors and exported in degrees.
- Add a shared `raypyng_analysis_metadata.json` sidecar file with the units of the analyzed output columns.
- Add `multiprocessing="auto"` and `multiprocessing="max"` modes to `Simulate.run()`.

### Changed
- Update examples to use `multiprocessing="auto"` instead of hardcoded worker counts.
- Update tutorial and how-to documentation to reflect the current simulation output structure, analyzed files, recap files, metadata sidecar, and multiprocessing options.
- Clean up several example scripts and fix stale file references and misleading comments.

### Fixed
- Fix a severe multiprocessing shutdown bug where simulations could finish writing outputs but the Python process could still hang during executor teardown.
- Prevent recursive retry of missing simulations while a previous `ProcessPoolExecutor` is still active.
- Handle unfinished futures more safely during shutdown, avoiding blocking exit when output files are already present.
- Fix postprocessing aggregation across repeated rounds by matching analyzed files by simulation index instead of file order.
- Ignore stale out-of-range analyzed files from previous runs during recap aggregation and final output checks.
- Reduce child-process cleanup output to a single terminal message instead of one line per PID.
