### PR TITLE
Release v1.4.1: fix raypyng analysis export-pair handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ src/raypyng.egg-info/top_level.txt
 examples/rml/new_elisa.rml
 examples/test_exportDetectorAtFocus-RawRaysOutgoing.csv
 examples/test_exportDipole-RawRaysOutgoing.csv
+
+# Sphinx build output
+docs/_build/
+
+.token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.4.1] - 18-May-2026
+
+### Added
+- Add lightweight repro script for mixed raypyng-analysis export configurations (`examples/repro/simulation_raypyng_lightweight.py`).
+- Add regression test covering mixed export pairs without cartesian-product assumptions (`tests/test_raypyng_analysis_export_mismatch.py`).
+
+### Changed
+
+### Fixed
+- Fix raypyng post-processing to respect exact `(object, export_type)` pairs configured in `sim.exports`.
+- Fix false missing-file failures caused by object/type cartesian-product lookup (for example unrequested `Dipole_RawRaysIncoming.csv`).
+- Fix recap/metadata generation to iterate configured export pairs only.
+- Improve missing-output errors to report only truly configured-but-missing analysis files.
+
+
 ## [1.4.0] - 16-April-2026
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raypyng"
-version = "1.4.0"
+version = "1.4.1"
 
 authors = [
   { name = "Simone Vadilonga, Ruslan Ovsyannikov, Sebastian Sachse", email = "simone.vadilonga@helmholtz-berlin.de" },

--- a/src/raypyng/postprocessing.py
+++ b/src/raypyng/postprocessing.py
@@ -511,8 +511,7 @@ class PostProcess:
         self,
         dir_path: str = None,
         repeat: int = 1,
-        exp_elements: list = None,
-        exported_file_type=None,
+        export_pairs: list = None,
     ):
         """Reads all the results of the postprocessing process and summarize
         them in a single file for each exported object.
@@ -524,8 +523,19 @@ class PostProcess:
         Args:
             dir_path (str, optional): The path to the folder to cleanup. Defaults to None.
             repeat (int, optional): number of rounds of simulations. Defaults to 1.
-            exp_elements (list, optional): the exported elements names as str. Defaults to None.
+            export_pairs (list, optional): list of (object_name, export_type) tuples.
         """
+        if export_pairs is None:
+            export_pairs = []
+
+        seen = set()
+        unique_export_pairs = []
+        for obj_name, export_type in export_pairs:
+            key = (obj_name, export_type)
+            if key not in seen:
+                seen.add(key)
+                unique_export_pairs.append(key)
+
         expected_simulations = len(
             {
                 self._extract_sim_index(path)
@@ -536,52 +546,61 @@ class PostProcess:
                 if self._extract_sim_index(path) is not None
             }
         )
-        for d in exp_elements:
-            for exp in exported_file_type:
-                analyzed_rays = None
-                for round in range(repeat):
-                    dir_path_round = os.path.join(dir_path, "round_" + str(round))
-                    files = self._list_files(
-                        dir_path_round, d + "_analyzed_rays_" + exp + self.format_saved_files
-                    )
-                    for f in files:
-                        sim_index = self._extract_sim_index(f)
-                        if sim_index is None or sim_index >= expected_simulations:
-                            continue
-                        tmp = pd.read_csv(f)
-                        tmp["_sim_index"] = sim_index
-                        if round == 0 and analyzed_rays is None:
-                            analyzed_rays = tmp
-                            analyzed_rays.set_index("_sim_index", inplace=True)
-                        elif round == 0:
-                            tmp.set_index("_sim_index", inplace=True)
+        missing_pairs = []
+        for obj_name, export_type in unique_export_pairs:
+            analyzed_rays = None
+            for round in range(repeat):
+                dir_path_round = os.path.join(dir_path, "round_" + str(round))
+                files = self._list_files(
+                    dir_path_round,
+                    obj_name + "_analyzed_rays_" + export_type + self.format_saved_files,
+                )
+                for f in files:
+                    sim_index = self._extract_sim_index(f)
+                    if sim_index is None or sim_index >= expected_simulations:
+                        continue
+                    tmp = pd.read_csv(f)
+                    tmp["_sim_index"] = sim_index
+                    if round == 0 and analyzed_rays is None:
+                        analyzed_rays = tmp
+                        analyzed_rays.set_index("_sim_index", inplace=True)
+                    elif round == 0:
+                        tmp.set_index("_sim_index", inplace=True)
+                        analyzed_rays = pd.concat([analyzed_rays, tmp], axis=0)
+                    else:
+                        tmp.set_index("_sim_index", inplace=True)
+                        if sim_index not in analyzed_rays.index:
                             analyzed_rays = pd.concat([analyzed_rays, tmp], axis=0)
                         else:
-                            tmp.set_index("_sim_index", inplace=True)
-                            if sim_index not in analyzed_rays.index:
-                                analyzed_rays = pd.concat([analyzed_rays, tmp], axis=0)
-                            else:
-                                for n in analyzed_rays.columns:
-                                    if isinstance(tmp.iloc[0][n], (int, float)):
-                                        analyzed_rays.loc[sim_index, n] += float(tmp.iloc[0][n])
-                        os.remove(f)
+                            for n in analyzed_rays.columns:
+                                if isinstance(tmp.iloc[0][n], (int, float)):
+                                    analyzed_rays.loc[sim_index, n] += float(tmp.iloc[0][n])
+                    os.remove(f)
 
-                if analyzed_rays is None:
-                    continue
+            if analyzed_rays is None:
+                missing_pairs.append((obj_name, export_type))
+                continue
 
-                def divide_numeric_rows(row):
-                    # Check if all elements in the row are of a numeric type
-                    if row.apply(lambda x: isinstance(x, (int, float))).all():
-                        return row / repeat
-                    else:
-                        return row
+            def divide_numeric_rows(row):
+                # Check if all elements in the row are of a numeric type
+                if row.apply(lambda x: isinstance(x, (int, float))).all():
+                    return row / repeat
+                else:
+                    return row
 
-                analyzed_rays = analyzed_rays.apply(divide_numeric_rows, axis=1)
-                analyzed_rays = analyzed_rays.sort_index().reset_index(drop=True)
-                # Apply the function across the DataFrame
-                # save the file
-                fn = os.path.join(dir_path, d + "_" + exp + ".csv")
-                analyzed_rays.to_csv(f"{fn}")
+            analyzed_rays = analyzed_rays.apply(divide_numeric_rows, axis=1)
+            analyzed_rays = analyzed_rays.sort_index().reset_index(drop=True)
+            # Apply the function across the DataFrame
+            # save the file
+            fn = os.path.join(dir_path, obj_name + "_" + export_type + ".csv")
+            analyzed_rays.to_csv(f"{fn}")
+
+        if missing_pairs:
+            missing_list = "\n".join(f"- {obj}_{exp}" for obj_, exp in missing_pairs)
+            raise FileNotFoundError(
+                "Missing analyzed ray export(s) for configured sim.exports pair(s):\n"
+                f"{missing_list}"
+            )
 
 
 class PostProcessAnalyzed:

--- a/src/raypyng/simulate.py
+++ b/src/raypyng/simulate.py
@@ -15,7 +15,7 @@ import pandas as pd
 import psutil
 from tqdm import tqdm
 
-from .helper_functions import RingBuffer, collect_unique_values
+from .helper_functions import RingBuffer
 from .postprocessing import PostProcess
 from .recipes import SimulationRecipe
 from .rml import ObjectElement, ParamElement, RMLFile
@@ -338,7 +338,6 @@ class Simulate:
         self._simulation_name = None  # Custom simulation name
         self._exports = []  # Files to export after simulation
         self._exports_list = []  # Processed list of exports
-        self._exported_obj_names_list = []  # List containing the names of the objects to export
         self._undulator_table = None  # holder for undulator table pandas dataframe
         self._efficiency = None  # holder for efficiency pandas dataframe
         self.sp = None  # SimulationParams instance
@@ -581,8 +580,6 @@ class Simulate:
         self._validate_export_list(value)
         self._exports = value
         self._exports_list = self._generate_exports_list(value)
-        self._exported_obj_names_list = self._generate_exported_obj_names_list(value)
-        self._exported_file_type = collect_unique_values(self._exports)
 
     def _validate_export_list(self, export_list):
         """
@@ -672,27 +669,6 @@ class Simulate:
                 for file in export_files:
                     exports_list.append((object_element.attributes().original()["name"], file))
         return exports_list
-
-    def _generate_exported_obj_names_list(self, export_list):
-        """
-        Generates a list with the names of the objects that will be exported.
-
-        Args:
-            export_list (list): The validated list of export configurations.
-
-        Returns:
-            list: A list of str representing the names of the objects to export.
-        """
-        self._exported_obj_names_list = []
-        for export_dict in export_list:
-            for object_element, export_files in export_dict.items():
-                if isinstance(export_files, str):
-                    export_files = [export_files]  # Ensure it's a list
-                for _file in export_files:
-                    self._exported_obj_names_list.append(
-                        object_element.attributes().original()["name"]
-                    )
-        return self._exported_obj_names_list
 
     @property
     def params(self):
@@ -1090,16 +1066,11 @@ class Simulate:
         if self.raypyng_analysis:
             self.logger.info("Starting cleanup")
             pp = PostProcess()
-            pp.cleanup(
-                self.sim_path,
-                self.repeat,
-                self._exported_obj_names_list,
-                exported_file_type=self._exported_file_type,
-            )
+            pp.cleanup(self.sim_path, self.repeat, export_pairs=self._exports_list)
             self.logger.info("Done with the cleanup")
             if self.analyze is False and self.raypyng_analysis is True:
                 self.logger.info("Create Pandas Recap Files")
-                self._create_results_dataframe(self._exported_file_type)
+                self._create_results_dataframe()
             self._write_analysis_metadata_file()
         if remove_round_folders:
             self._remove_round_folders()
@@ -1149,20 +1120,39 @@ class Simulate:
             if os.path.exists(round_folder_path):
                 shutil.rmtree(round_folder_path)
 
-    def _create_results_dataframe(self, exported_file_type):
+    def _iter_unique_export_pairs(self):
+        """Yield unique (object_name, export_type) pairs preserving first-seen order."""
+        seen = set()
+        for obj_name, export_type in self._exports_list:
+            key = (obj_name, export_type)
+            if key not in seen:
+                seen.add(key)
+                yield key
+
+    def _create_results_dataframe(self):
         looper_path = os.path.join(self.sim_path, "looper.csv")
         looper = pd.read_csv(looper_path)
-        for export in self._exported_obj_names_list:
-            for in_out in exported_file_type:
-                oe_path = os.path.join(self.sim_path, f"{export}_{in_out}.csv")
-                # Reading the data into a DataFrame, specify no comment
-                # handling and read headers normally
-                res = pd.read_csv(oe_path, comment=None, header=0, index_col=False)
-                # Manually remove the '#' from the first column name
-                res.columns = [col.replace("#", "").strip() for col in res.columns]
-                res_combined = pd.concat([looper, res], axis=1)
-                res_combined = res_combined.loc[:, ~res_combined.columns.str.contains("^Unnamed")]
-                res_combined.to_csv(os.path.join(self.sim_path, f"{export}_{in_out}.csv"))
+        missing_files = []
+        for export, in_out in self._iter_unique_export_pairs():
+            oe_path = os.path.join(self.sim_path, f"{export}_{in_out}.csv")
+            if not os.path.exists(oe_path):
+                missing_files.append(oe_path)
+                continue
+            # Reading the data into a DataFrame, specify no comment
+            # handling and read headers normally
+            res = pd.read_csv(oe_path, comment=None, header=0, index_col=False)
+            # Manually remove the '#' from the first column name
+            res.columns = [col.replace("#", "").strip() for col in res.columns]
+            res_combined = pd.concat([looper, res], axis=1)
+            res_combined = res_combined.loc[:, ~res_combined.columns.str.contains("^Unnamed")]
+            res_combined.to_csv(os.path.join(self.sim_path, f"{export}_{in_out}.csv"))
+
+        if missing_files:
+            formatted = "\n".join(f"- {path}" for path in missing_files)
+            raise FileNotFoundError(
+                "Missing expected analysis export file(s) for configured sim.exports:\n"
+                f"{formatted}"
+            )
 
     def _unit_for_output_column(self, column_name):
         analysis_units = {
@@ -1204,12 +1194,11 @@ class Simulate:
 
     def _write_analysis_metadata_file(self):
         sample_columns = None
-        for export in self._exported_obj_names_list:
-            for in_out in self._exported_file_type:
-                output_path = os.path.join(self.sim_path, f"{export}_{in_out}.csv")
-                if os.path.exists(output_path):
-                    sample_columns = list(pd.read_csv(output_path, nrows=0).columns)
-                    break
+        for export, in_out in self._iter_unique_export_pairs():
+            output_path = os.path.join(self.sim_path, f"{export}_{in_out}.csv")
+            if os.path.exists(output_path):
+                sample_columns = list(pd.read_csv(output_path, nrows=0).columns)
+                break
             if sample_columns is not None:
                 break
 

--- a/tests/test_raypyng_analysis_export_mismatch.py
+++ b/tests/test_raypyng_analysis_export_mismatch.py
@@ -1,0 +1,61 @@
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "examples" / "repro" / "simulation_raypyng_lightweight.py"
+
+
+def _can_run_rayui() -> bool:
+    if shutil.which("xvfb-run") is None:
+        return False
+
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    try:
+        from raypyng.runner import RayUIRunner
+
+        RayUIRunner(hide=True)
+    except Exception:
+        return False
+    return True
+
+
+@pytest.mark.skipif(not _can_run_rayui(), reason="Ray-UI/xvfb environment not available")
+def test_raypyng_analysis_export_mismatch_repro_only(tmp_path: Path):
+    env = os.environ.copy()
+    pythonpath_entries = [str(REPO_ROOT / "src")]
+    if env.get("PYTHONPATH"):
+        pythonpath_entries.append(env["PYTHONPATH"])
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
+
+    out_dir = tmp_path / "repro"
+    cmd = [
+        sys.executable,
+        str(SCRIPT_PATH),
+        "--output-dir",
+        str(out_dir),
+    ]
+
+    proc = subprocess.run(
+        cmd,
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    text = f"{proc.stdout}\n{proc.stderr}"
+
+    # Mixed export expectation: should succeed and only process configured pairs.
+    assert proc.returncode == 0, text
+    assert "Traceback" not in text
+
+    sim_dir = out_dir / "RAYPy_Simulation_raypyng_lightweight_repro"
+    assert (sim_dir / "Dipole_RawRaysOutgoing.csv").exists()
+    assert (sim_dir / "ExitSlit_RawRaysOutgoing.csv").exists()
+    assert (sim_dir / "ExitSlit_RawRaysIncoming.csv").exists()
+    assert not (sim_dir / "Dipole_RawRaysIncoming.csv").exists()


### PR DESCRIPTION
## Summary
This patch release fixes a raypyng post-processing bug where analysis assumed a cartesian product of exported objects and export types.

## Problem
With `sim.raypyng_analysis=True`, mixed export configs (for example one element exporting only `RawRaysOutgoing`, another exporting both `RawRaysOutgoing` and `RawRaysIncoming`) could crash after simulation completion with a false `FileNotFoundError` for an unrequested file (e.g. `Dipole_RawRaysIncoming.csv`).

## What changed
- Use exact `(object, export_type)` pairs from `sim.exports` as the source of truth in post-processing.
- Remove cartesian-product lookup during cleanup/recap/metadata generation.
- Keep strict missing-file behavior only for truly configured-but-missing outputs.
- Add regression test for mixed export pairs.
- Bump version to `1.4.1` and update changelog.
- Add `.token` to `.gitignore` to prevent local token file commits.

## Validation
- `python -m py_compile` on changed python files passed locally.
- Runtime pytest is environment-dependent on Ray-UI/xvfb; test includes skip guard when unavailable.

## Notes
This MR is intentionally scoped to the analysis/export pair fix plus release metadata for `1.4.1`.
