### PR TITLE
Fix raypyng analysis export-pair handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.4.1] - 18-May-2026
+
+### Added
+- Add regression test for mixed export-pair handling in raypyng analysis (`tests/test_raypyng_analysis_export_mismatch.py`).
+
+### Changed
+
+### Fixed
+- Fix raypyng post-processing to respect exact `(object, export_type)` pairs configured in `sim.exports`.
+- Prevent false cartesian-product lookups that required unrequested files (for example `M1_hor_foc_RawRaysIncoming.csv` when only outgoing was requested).
+- Generate recap/dataframe and analysis metadata using configured export pairs only.
+- Raise clear missing-file errors only for truly configured-but-missing analysis outputs.
+
 ## [1.4.0] - 16-April-2026
 
 ### Added
@@ -166,6 +179,5 @@ All notable changes to this project will be documented in this file.
  
 ### Fixed
 - issue [#29](https://github.com/hz-b/raypyng/issues/29), Simulate.params used to throw an error when attempting list step-wise operation.
-
 
 

--- a/src/raypyng/postprocessing.py
+++ b/src/raypyng/postprocessing.py
@@ -511,8 +511,7 @@ class PostProcess:
         self,
         dir_path: str = None,
         repeat: int = 1,
-        exp_elements: list = None,
-        exported_file_type=None,
+        export_pairs: list = None,
     ):
         """Reads all the results of the postprocessing process and summarize
         them in a single file for each exported object.
@@ -524,8 +523,17 @@ class PostProcess:
         Args:
             dir_path (str, optional): The path to the folder to cleanup. Defaults to None.
             repeat (int, optional): number of rounds of simulations. Defaults to 1.
-            exp_elements (list, optional): the exported elements names as str. Defaults to None.
+            export_pairs (list, optional): list of (object_name, export_type) tuples.
         """
+        export_pairs = [] if export_pairs is None else export_pairs
+        unique_export_pairs = []
+        seen = set()
+        for export_pair in export_pairs:
+            if export_pair in seen:
+                continue
+            seen.add(export_pair)
+            unique_export_pairs.append(export_pair)
+
         expected_simulations = len(
             {
                 self._extract_sim_index(path)
@@ -536,52 +544,61 @@ class PostProcess:
                 if self._extract_sim_index(path) is not None
             }
         )
-        for d in exp_elements:
-            for exp in exported_file_type:
-                analyzed_rays = None
-                for round in range(repeat):
-                    dir_path_round = os.path.join(dir_path, "round_" + str(round))
-                    files = self._list_files(
-                        dir_path_round, d + "_analyzed_rays_" + exp + self.format_saved_files
-                    )
-                    for f in files:
-                        sim_index = self._extract_sim_index(f)
-                        if sim_index is None or sim_index >= expected_simulations:
-                            continue
-                        tmp = pd.read_csv(f)
-                        tmp["_sim_index"] = sim_index
-                        if round == 0 and analyzed_rays is None:
-                            analyzed_rays = tmp
-                            analyzed_rays.set_index("_sim_index", inplace=True)
-                        elif round == 0:
-                            tmp.set_index("_sim_index", inplace=True)
+        missing_pairs = []
+        for object_name, export_type in unique_export_pairs:
+            analyzed_rays = None
+            for round in range(repeat):
+                dir_path_round = os.path.join(dir_path, "round_" + str(round))
+                files = self._list_files(
+                    dir_path_round,
+                    object_name + "_analyzed_rays_" + export_type + self.format_saved_files,
+                )
+                for f in files:
+                    sim_index = self._extract_sim_index(f)
+                    if sim_index is None or sim_index >= expected_simulations:
+                        continue
+                    tmp = pd.read_csv(f)
+                    tmp["_sim_index"] = sim_index
+                    if round == 0 and analyzed_rays is None:
+                        analyzed_rays = tmp
+                        analyzed_rays.set_index("_sim_index", inplace=True)
+                    elif round == 0:
+                        tmp.set_index("_sim_index", inplace=True)
+                        analyzed_rays = pd.concat([analyzed_rays, tmp], axis=0)
+                    else:
+                        tmp.set_index("_sim_index", inplace=True)
+                        if sim_index not in analyzed_rays.index:
                             analyzed_rays = pd.concat([analyzed_rays, tmp], axis=0)
                         else:
-                            tmp.set_index("_sim_index", inplace=True)
-                            if sim_index not in analyzed_rays.index:
-                                analyzed_rays = pd.concat([analyzed_rays, tmp], axis=0)
-                            else:
-                                for n in analyzed_rays.columns:
-                                    if isinstance(tmp.iloc[0][n], (int, float)):
-                                        analyzed_rays.loc[sim_index, n] += float(tmp.iloc[0][n])
-                        os.remove(f)
+                            for n in analyzed_rays.columns:
+                                if isinstance(tmp.iloc[0][n], (int, float)):
+                                    analyzed_rays.loc[sim_index, n] += float(tmp.iloc[0][n])
+                    os.remove(f)
 
-                if analyzed_rays is None:
-                    continue
+            if analyzed_rays is None:
+                missing_pairs.append((object_name, export_type))
+                continue
 
-                def divide_numeric_rows(row):
-                    # Check if all elements in the row are of a numeric type
-                    if row.apply(lambda x: isinstance(x, (int, float))).all():
-                        return row / repeat
-                    else:
-                        return row
+            def divide_numeric_rows(row):
+                # Check if all elements in the row are of a numeric type
+                if row.apply(lambda x: isinstance(x, (int, float))).all():
+                    return row / repeat
+                else:
+                    return row
 
-                analyzed_rays = analyzed_rays.apply(divide_numeric_rows, axis=1)
-                analyzed_rays = analyzed_rays.sort_index().reset_index(drop=True)
-                # Apply the function across the DataFrame
-                # save the file
-                fn = os.path.join(dir_path, d + "_" + exp + ".csv")
-                analyzed_rays.to_csv(f"{fn}")
+            analyzed_rays = analyzed_rays.apply(divide_numeric_rows, axis=1)
+            analyzed_rays = analyzed_rays.sort_index().reset_index(drop=True)
+            # Apply the function across the DataFrame
+            # save the file
+            fn = os.path.join(dir_path, object_name + "_" + export_type + ".csv")
+            analyzed_rays.to_csv(f"{fn}")
+
+        if missing_pairs:
+            missing_text = "\n".join(f"- {obj}_{exp}" for obj, exp in missing_pairs)
+            raise FileNotFoundError(
+                "Missing analyzed ray export file(s) for configured sim.exports:\n"
+                f"{missing_text}"
+            )
 
 
 class PostProcessAnalyzed:

--- a/src/raypyng/simulate.py
+++ b/src/raypyng/simulate.py
@@ -15,7 +15,7 @@ import pandas as pd
 import psutil
 from tqdm import tqdm
 
-from .helper_functions import RingBuffer, collect_unique_values
+from .helper_functions import RingBuffer
 from .postprocessing import PostProcess
 from .recipes import SimulationRecipe
 from .rml import ObjectElement, ParamElement, RMLFile
@@ -418,7 +418,6 @@ class Simulate:
         self._simulation_name = None  # Custom simulation name
         self._exports = []  # Files to export after simulation
         self._exports_list = []  # Processed list of exports
-        self._exported_obj_names_list = []  # List containing the names of the objects to export
         self._undulator_table = None  # holder for undulator table pandas dataframe
         self._efficiency = None  # holder for efficiency pandas dataframe
         self.sp = None  # SimulationParams instance
@@ -670,8 +669,6 @@ class Simulate:
         self._validate_export_list(copied_value)
         self._exports = copied_value
         self._exports_list = self._generate_exports_list(copied_value)
-        self._exported_obj_names_list = self._generate_exported_obj_names_list(copied_value)
-        self._exported_file_type = collect_unique_values(self._exports)
 
     def _copy_export_list(self, value):
         if not isinstance(value, list):
@@ -782,26 +779,14 @@ class Simulate:
                     exports_list.append((object_element.attributes().original()["name"], file))
         return exports_list
 
-    def _generate_exported_obj_names_list(self, export_list):
-        """
-        Generates a list with the names of the objects that will be exported.
-
-        Args:
-            export_list (list): The validated list of export configurations.
-
-        Returns:
-            list: A list of str representing the names of the objects to export.
-        """
-        self._exported_obj_names_list = []
-        for export_dict in export_list:
-            for object_element, export_files in export_dict.items():
-                if isinstance(export_files, str):
-                    export_files = [export_files]  # Ensure it's a list
-                for _file in export_files:
-                    self._exported_obj_names_list.append(
-                        object_element.attributes().original()["name"]
-                    )
-        return self._exported_obj_names_list
+    def _iter_unique_export_pairs(self):
+        """Yield unique (object_name, export_type) pairs in first-seen order."""
+        seen = set()
+        for export_pair in self._exports_list:
+            if export_pair in seen:
+                continue
+            seen.add(export_pair)
+            yield export_pair
 
     @property
     def params(self):
@@ -1202,16 +1187,11 @@ class Simulate:
         if self.raypyng_analysis:
             self.logger.info("Starting cleanup")
             pp = PostProcess()
-            pp.cleanup(
-                self.sim_path,
-                self.repeat,
-                self._exported_obj_names_list,
-                exported_file_type=self._exported_file_type,
-            )
+            pp.cleanup(self.sim_path, self.repeat, export_pairs=self._exports_list)
             self.logger.info("Done with the cleanup")
             if self.analyze is False and self.raypyng_analysis is True:
                 self.logger.info("Create Pandas Recap Files")
-                self._create_results_dataframe(self._exported_file_type)
+                self._create_results_dataframe()
             self._write_analysis_metadata_file()
         if remove_round_folders:
             self._remove_round_folders()
@@ -1261,20 +1241,31 @@ class Simulate:
             if os.path.exists(round_folder_path):
                 shutil.rmtree(round_folder_path)
 
-    def _create_results_dataframe(self, exported_file_type):
+    def _create_results_dataframe(self):
         looper_path = os.path.join(self.sim_path, "looper.csv")
         looper = pd.read_csv(looper_path)
-        for export in self._exported_obj_names_list:
-            for in_out in exported_file_type:
-                oe_path = os.path.join(self.sim_path, f"{export}_{in_out}.csv")
-                # Reading the data into a DataFrame, specify no comment
-                # handling and read headers normally
-                res = pd.read_csv(oe_path, comment=None, header=0, index_col=False)
-                # Manually remove the '#' from the first column name
-                res.columns = [col.replace("#", "").strip() for col in res.columns]
-                res_combined = pd.concat([looper, res], axis=1)
-                res_combined = res_combined.loc[:, ~res_combined.columns.str.contains("^Unnamed")]
-                res_combined.to_csv(os.path.join(self.sim_path, f"{export}_{in_out}.csv"))
+        missing_files = []
+        for export, in_out in self._iter_unique_export_pairs():
+            oe_path = os.path.join(self.sim_path, f"{export}_{in_out}.csv")
+            if not os.path.exists(oe_path):
+                missing_files.append(oe_path)
+                continue
+
+            # Reading the data into a DataFrame, specify no comment
+            # handling and read headers normally
+            res = pd.read_csv(oe_path, comment=None, header=0, index_col=False)
+            # Manually remove the '#' from the first column name
+            res.columns = [col.replace("#", "").strip() for col in res.columns]
+            res_combined = pd.concat([looper, res], axis=1)
+            res_combined = res_combined.loc[:, ~res_combined.columns.str.contains("^Unnamed")]
+            res_combined.to_csv(os.path.join(self.sim_path, f"{export}_{in_out}.csv"))
+
+        if missing_files:
+            formatted = "\n".join(f"- {path}" for path in missing_files)
+            raise FileNotFoundError(
+                "Missing expected analysis output file(s) for configured sim.exports:\n"
+                f"{formatted}"
+            )
 
     def _unit_for_output_column(self, column_name):
         analysis_units = {
@@ -1316,13 +1307,10 @@ class Simulate:
 
     def _write_analysis_metadata_file(self):
         sample_columns = None
-        for export in self._exported_obj_names_list:
-            for in_out in self._exported_file_type:
-                output_path = os.path.join(self.sim_path, f"{export}_{in_out}.csv")
-                if os.path.exists(output_path):
-                    sample_columns = list(pd.read_csv(output_path, nrows=0).columns)
-                    break
-            if sample_columns is not None:
+        for export, in_out in self._iter_unique_export_pairs():
+            output_path = os.path.join(self.sim_path, f"{export}_{in_out}.csv")
+            if os.path.exists(output_path):
+                sample_columns = list(pd.read_csv(output_path, nrows=0).columns)
                 break
 
         if sample_columns is None:

--- a/tests/test_raypyng_analysis_export_mismatch.py
+++ b/tests/test_raypyng_analysis_export_mismatch.py
@@ -1,0 +1,59 @@
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "examples" / "repro" / "simulation_raypyng_lightweight.py"
+
+
+def _can_run_rayui() -> bool:
+    if shutil.which("xvfb-run") is None:
+        return False
+
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    try:
+        from raypyng.runner import RayUIRunner
+
+        RayUIRunner(hide=True)
+    except Exception:
+        return False
+    return True
+
+
+@pytest.mark.skipif(not _can_run_rayui(), reason="Ray-UI/xvfb environment not available")
+def test_raypyng_analysis_export_mismatch(tmp_path: Path):
+    env = os.environ.copy()
+    pythonpath_entries = [str(REPO_ROOT / "src")]
+    if env.get("PYTHONPATH"):
+        pythonpath_entries.append(env["PYTHONPATH"])
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
+
+    out_dir = tmp_path / "repro"
+    cmd = [
+        sys.executable,
+        str(SCRIPT_PATH),
+        "--output-dir",
+        str(out_dir),
+    ]
+
+    proc = subprocess.run(
+        cmd,
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    text = f"{proc.stdout}\n{proc.stderr}"
+    assert proc.returncode == 0, text
+    assert "Traceback" not in text
+
+    sim_dir = out_dir / "RAYPy_Simulation_raypyng_lightweight_repro"
+    assert (sim_dir / "Dipole_RawRaysOutgoing.csv").exists()
+    assert (sim_dir / "ExitSlit_RawRaysOutgoing.csv").exists()
+    assert (sim_dir / "ExitSlit_RawRaysIncoming.csv").exists()
+    assert not (sim_dir / "Dipole_RawRaysIncoming.csv").exists()


### PR DESCRIPTION
## Summary
Fix post-processing in `raypyng_analysis` so it respects exact `(object, export_type)` pairs from `sim.exports` instead of building a cartesian product.

## Problem
Mixed export setups (for example one element with outgoing only and another with incoming+outgoing) could fail after simulation completion with `FileNotFoundError` for unrequested files such as `M1_hor_foc_RawRaysIncoming.csv`.

## Changes
- `Simulate.run()` now passes exact export pairs into post-processing cleanup.
- Recap dataframe generation iterates configured export pairs only.
- Metadata generation scans configured export pairs only.
- `PostProcess.cleanup()` now processes explicit export pairs instead of `elements × file_types`.
- Added regression test: `tests/test_raypyng_analysis_export_mismatch.py`.
- Updated changelog for `1.4.1`.

## Validation
- `python -m py_compile src/raypyng/simulate.py src/raypyng/postprocessing.py tests/test_raypyng_analysis_export_mismatch.py`
- Runtime pytest remains environment-dependent on Ray-UI/xvfb.
