### PR TITLE
docs: copy-pasteable tutorials, parameter guide, FAQ, flux/efficiency tables, OS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,6 @@ venv_docs/
 .vscode/targets.log
 
 # ignore output of examples/tests
-examples/rml/new_elisa.rml
+examples/rml/new_dipole_beamline.rml
 examples/test_exportDetectorAtFocus-RawRaysOutgoing.csv
 examples/test_exportDipole-RawRaysOutgoing.csv

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # python virtual environment
 .venv/
 .token
-docs
 # python specific
 __pycache__/
 
@@ -24,6 +23,7 @@ src/raypyng.egg-info/top_level.txt
 
 # Sphinx build output and docs venvs
 docs/_build/
+docs/images/
 venv_docs/
 
 #ignore vscode stuff

--- a/docs/how_to.rst
+++ b/docs/how_to.rst
@@ -80,86 +80,82 @@ in :code:`simulation_name()`
 How To Write a Recipe
 ---------------------
 
-An example of how to write a recipe that exports 
-file for each element present in the beamline automatically.  
- 
- .. code-block:: python
+An example of how to write a recipe that automatically exports a
+file for each element present in the beamline:
+
+.. code-block:: python
+
+    from raypyng.recipes import SimulationRecipe
+
 
     class ExportEachElement(SimulationRecipe):
-    """At one defined energy export a file for each 
-    optical elements
-    """
-    def __init__(self, energy:float,/,nrays:int=None,sim_folder:str=None):
-        """
-        Args:
-            energy_range (np.array, list): the energies to simulate in eV
-            nrays (int): number of rays for the source
-            sim_folder (str, optional): the name of the simulation folder. If None, the rml filename will be used. Defaults to None.
-        
-        """        
-    
-        if not isinstance(energy, (int,float)):
-           raise TypeError('The energy must be an a int or float, while it is a', type(energy))
+        """At one defined energy, export a file for each optical element."""
 
-        self.energy = energy
-        self.nrays  = nrays
-        self.sim_folder = sim_folder
-    
-    def params(self,sim:Simulate):
-        params = []
+        def __init__(self, energy: float, /, nrays: int = None, sim_folder: str = None):
+            """
+            Args:
+                energy (float): the energy to simulate, in eV
+                nrays (int): number of rays for the source
+                sim_folder (str, optional): the name of the simulation folder.
+                    If None, the rml filename will be used. Defaults to None.
+            """
+            if not isinstance(energy, (int, float)):
+                raise TypeError(
+                    'The energy must be an int or float, while it is a', type(energy)
+                )
 
-        # find source and add to param with defined user energy range
-        found_source = False
-        for oe in sim.rml.beamline.children():
-            if hasattr(oe,"photonEnergy"):
-            self.source = oe
-                found_source = True
-                break        
-        if found_source!=True:
-            raise AttributeError('I did not find the source')        
-        params.append({self.source.photonEnergy:self.energy})
-        
-        # set reflectivity to 100%
-        for oe in sim.rml.beamline.children():
+            self.energy = energy
+            self.nrays = nrays
+            self.sim_folder = sim_folder
+
+        def params(self, sim):
+            params = []
+
+            # find the source and scan it over the user-defined energy range
+            found_source = False
+            for oe in sim.rml.beamline.children():
+                if hasattr(oe, "photonEnergy"):
+                    self.source = oe
+                    found_source = True
+                    break
+            if not found_source:
+                raise AttributeError('I did not find the source')
+            params.append({self.source.photonEnergy: self.energy})
+
+            # set reflectivity to 100% on every element that supports it
+            for oe in sim.rml.beamline.children():
                 for par in oe:
                     try:
-                        params.append({par.reflectivityType:0})
-                    except:
+                        params.append({par.reflectivityType: 0})
+                    except Exception:
                         pass
 
-        # all done, return resulting params
-        return params
+            # all done, return the resulting params
+            return params
 
-    def exports(self,sim:Simulate):
-        # find all the elements in the beamline
-        oe_list=[]
-        for oe in sim.rml.beamline.children():
-            oe_list.append(oe)
-        # compose the export list of dictionaries
-        exports = []
-        for oe in oe_list:
-            exports.append({oe:'RawRaysOutgoing'})
-        return exports
+        def exports(self, sim):
+            # export RawRaysOutgoing for every element in the beamline
+            exports = []
+            for oe in sim.rml.beamline.children():
+                exports.append({oe: 'RawRaysOutgoing'})
+            return exports
 
-    def simulation_name(self,sim:Simulate):
-        if self.sim_folder is None:
-            return 'ExportEachElement'
-        else: 
+        def simulation_name(self, sim):
+            if self.sim_folder is None:
+                return 'ExportEachElement'
             return self.sim_folder
+
+
     if __name__ == "__main__":
         from raypyng import Simulate
-        import numpy as np
-        import os
 
-        rml_file = ('rml_file.rml')
-        sim      = Simulate(rml_file, hide=True)
-
+        rml_file = 'rml_file.rml'
+        sim = Simulate(rml_file, hide=True)
 
         sim.analyze = False
 
-        myRecipe = ExportEachElement(energy=1000,nrays=10000,sim_folder='MyRecipeTest')
+        myRecipe = ExportEachElement(energy=1000, nrays=10000, sim_folder='MyRecipeTest')
 
-        # test resolving power simulations
         sim.run(myRecipe, multiprocessing="auto", force=True)
 
 How to work with Undulator File
@@ -183,7 +179,7 @@ WAVE simulation files for the first, third and fifth harmonic, and the Undulator
 
 This produces the following output:
 
-.. code:: python
+.. code-block:: text
 
     I found the following harmonics: dict_keys([1, 3, 5])
     the energy points for each harmonic are equally spaced
@@ -198,7 +194,7 @@ This produces the following output:
     Harmonic number 5, available energies:
     start 400
     stop 2850
-    step 50 
+    step 50
 
 
 We can now extract the file location for all the energies or a subset of the 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,12 +5,55 @@
 
 Welcome to raypyng's documentation!
 ===================================
-raypyng provides a simple python API to work with 
-`RAY-UI 
-<https://www.helmholtz-berlin.de/forschung/oe/wi/optik-strahlrohre/arbeitsgebiete/ray_en.html>`_, 
-a software for optical simulation of synchrotron 
-beamlines and x-ray systems developed by 
+raypyng provides a simple python API to work with
+`RAY-UI
+<https://www.helmholtz-berlin.de/forschung/oe/wi/optik-strahlrohre/arbeitsgebiete/ray_en.html>`_,
+a software for optical simulation of synchrotron
+beamlines and x-ray systems developed by
 Helmholtz-Zentrum Berlin.
+
+raypyng loads a beamline saved from RAY-UI as an ``.rml`` file, scans any number
+of its parameters, runs the traces in parallel, and post-processes the exported
+rays for you.
+
+Quickstart
+----------
+You need a beamline ``.rml`` file created and saved with RAY-UI. The following
+minimal script scans the photon energy of a dipole source and writes the
+analyzed rays at the focus:
+
+.. code-block:: python
+
+    import numpy as np
+    from raypyng import Simulate
+
+    if __name__ == '__main__':
+        # a beamline previously saved from RAY-UI
+        sim = Simulate('rml/elisa.rml', hide=True)
+        beamline = sim.rml.beamline
+
+        # scan the source photon energy
+        sim.params = [
+            {beamline.Dipole.photonEnergy: np.arange(200, 2001, 200)},
+        ]
+
+        sim.simulation_name = 'quickstart'
+        sim.analyze = False          # let raypyng (not RAY-UI) analyze the rays
+        sim.raypyng_analysis = True
+        sim.exports = [{beamline.DetectorAtFocus: ['RawRaysOutgoing']}]
+
+        # run, using as many parallel RAY-UI instances as the machine allows
+        sim.run(multiprocessing="auto", force=True)
+
+The results are written to a ``RAYPy_Simulation_quickstart`` folder. See the
+:doc:`tutorial` for a full walk-through, including how the parameters combine and
+how to read the output.
+
+.. note::
+
+   The ``if __name__ == '__main__':`` guard is required on macOS and Windows,
+   where raypyng's parallel workers re-import your script. See the
+   :doc:`tutorial` for details.
 
 
 .. toctree::
@@ -20,6 +63,7 @@ Helmholtz-Zentrum Berlin.
    installation
    tutorial
    how_to
+   troubleshooting
    API
    
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,9 +51,10 @@ how to read the output.
 
 .. note::
 
-   The ``if __name__ == '__main__':`` guard is required on macOS and Windows,
-   where raypyng's parallel workers re-import your script. See the
-   :doc:`tutorial` for details.
+   The ``if __name__ == '__main__':`` guard is required on macOS, where
+   raypyng's parallel workers re-import your script. See the :doc:`tutorial`
+   for details. (raypyng runs simulations on Linux and macOS only — not on
+   Windows.)
 
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ analyzed rays at the focus:
 
     if __name__ == '__main__':
         # a beamline previously saved from RAY-UI
-        sim = Simulate('rml/elisa.rml', hide=True)
+        sim = Simulate('rml/dipole_beamline.rml', hide=True)
         beamline = sim.rml.beamline
 
         # scan the source photon energy

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,8 +1,18 @@
 Installation
 *************
-raypyng works on both **Linux** and **macOS**.
+raypyng runs the simulations on **Linux** and **macOS**.
 
-The installation has two parts that are common to every platform:
+.. warning::
+
+   **Windows is not supported for running simulations.** Driving RAY-UI from
+   Python relies on RAY-UI's *background mode*, which lets raypyng send commands
+   and read results over a pipe. RAY-UI does not provide a background mode on
+   Windows, so there is no way for raypyng to communicate with it there. The
+   pure-Python helpers that do not launch RAY-UI (for example reading/writing
+   ``.rml`` files or the standalone ``Dipole`` spectrum) may still work on
+   Windows, but the whole simulation workflow does not.
+
+The installation has two parts that are common to every supported platform:
 
 #. Install **RAY-UI**, the ray-tracing engine that raypyng drives.
 #. Install the **raypyng** Python package.

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -1,0 +1,80 @@
+Troubleshooting / FAQ
+*********************
+
+A short list of the most common questions and pitfalls. Many of these are also
+mentioned in context in the :doc:`installation` and :doc:`tutorial` pages; they
+are collected here for convenience.
+
+Do I need the ``if __name__ == '__main__':`` guard?
+===================================================
+**Yes, on macOS and Windows.** raypyng runs the simulations in parallel through
+Python's :code:`multiprocessing`. On macOS and Windows the worker processes are
+created with the :code:`spawn` start method, which **re-imports your script** in
+every worker. If the call to :code:`sim.run()` is not protected by
+:code:`if __name__ == '__main__':`, each worker re-runs it on import, leading to
+runaway process creation and a :code:`RuntimeError` about the bootstrapping
+phase.
+
+On Linux the default start method is :code:`fork`, which does not re-import the
+script, so the guard is not strictly required there — but adding it is harmless
+and makes the same script work on every platform.
+
+I get a ``RuntimeError`` about "bootstrapping phase"
+====================================================
+This is the symptom of the missing guard described above. Wrap your simulation
+setup and the :code:`sim.run()` call in :code:`if __name__ == '__main__':`.
+
+On macOS, "Ray-UI is not responding" / "Ray-UI quit unexpectedly"
+=================================================================
+**This is harmless and can be ignored.** While simulations run, macOS may
+sporadically show a dialog saying that Ray-UI is not responding or quit
+unexpectedly. It is just macOS noticing that the headless RAY-UI instances are
+started and stopped rapidly. The simulations are not affected and complete
+normally — simply dismiss the dialogs.
+
+Do I need to install xvfb?
+==========================
+**Only on Linux.** On Linux, xvfb provides the virtual X11 framebuffer that lets
+RAY-UI run headless, and raypyng uses ``xvfb-run`` automatically. On macOS xvfb
+is **not** needed and must not be installed; raypyng skips it automatically and
+the :code:`hide` parameter is simply ignored.
+
+raypyng cannot find RAY-UI
+==========================
+By default raypyng searches the standard installation folders. If your
+installation is elsewhere, pass the path explicitly:
+
+.. code-block:: python
+
+    sim = Simulate('rml/elisa.rml', hide=True, ray_path='/path/to/RAY-UI')
+
+On macOS the installer creates a ``Ray-UI.app`` bundle, so the installation
+folder is the directory that *contains* ``Ray-UI.app`` (for example
+``~/Applications/RAY-UI``), not the ``.app`` itself.
+
+How many parallel instances should I use?
+=========================================
+The ``multiprocessing`` argument to :code:`sim.run()` controls how many RAY-UI
+instances run in parallel:
+
+- an integer ``>= 1`` — that exact number of instances,
+- ``"auto"`` — the minimum between the available CPU count and the available
+  RAM in GB minus 2,
+- ``"max"`` — the minimum between the available CPU count and the available RAM
+  in GB.
+
+As a rule of thumb, do not use more instances than you have CPU cores. If your
+simulations use many rays, watch the RAM usage: if the machine runs out of
+memory the program may block or produce incorrect results. In that case reduce
+the number of parallel instances or the number of rays.
+
+My simulations are slow
+=======================
+The speedup from running many RAY-UI instances in parallel is effective only
+when RAY-UI is **not** doing the analysis. Prefer letting raypyng analyze the
+results:
+
+.. code-block:: python
+
+    sim.analyze = False          # don't let RAY-UI analyze the results
+    sim.raypyng_analysis = True  # let raypyng analyze the results

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -46,7 +46,7 @@ installation is elsewhere, pass the path explicitly:
 
 .. code-block:: python
 
-    sim = Simulate('rml/elisa.rml', hide=True, ray_path='/path/to/RAY-UI')
+    sim = Simulate('rml/dipole_beamline.rml', hide=True, ray_path='/path/to/RAY-UI')
 
 On macOS the installer creates a ``Ray-UI.app`` bundle, so the installation
 folder is the directory that *contains* ``Ray-UI.app`` (for example

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -5,19 +5,29 @@ A short list of the most common questions and pitfalls. Many of these are also
 mentioned in context in the :doc:`installation` and :doc:`tutorial` pages; they
 are collected here for convenience.
 
+Does raypyng work on Windows?
+=============================
+**No, not for running simulations.** Driving RAY-UI from Python relies on
+RAY-UI's *background mode*, which is the channel raypyng uses to send commands
+and read back results. RAY-UI does not offer a background mode on Windows, so
+there is no way for raypyng to communicate with it. The simulation workflow is
+therefore supported on **Linux and macOS only**. Pure-Python helpers that do not
+launch RAY-UI (reading/writing ``.rml`` files, the standalone ``Dipole``
+spectrum, the diode conversion, …) may still work on Windows.
+
 Do I need the ``if __name__ == '__main__':`` guard?
 ===================================================
-**Yes, on macOS and Windows.** raypyng runs the simulations in parallel through
-Python's :code:`multiprocessing`. On macOS and Windows the worker processes are
-created with the :code:`spawn` start method, which **re-imports your script** in
-every worker. If the call to :code:`sim.run()` is not protected by
+**Yes, on macOS.** raypyng runs the simulations in parallel through Python's
+:code:`multiprocessing`. On macOS the worker processes are created with the
+:code:`spawn` start method, which **re-imports your script** in every worker. If
+the call to :code:`sim.run()` is not protected by
 :code:`if __name__ == '__main__':`, each worker re-runs it on import, leading to
 runaway process creation and a :code:`RuntimeError` about the bootstrapping
 phase.
 
 On Linux the default start method is :code:`fork`, which does not re-import the
 script, so the guard is not strictly required there — but adding it is harmless
-and makes the same script work on every platform.
+and keeps the same script working on both supported platforms.
 
 I get a ``RuntimeError`` about "bootstrapping phase"
 ====================================================

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -475,13 +475,13 @@ Finally, the simulations can be run using
 
    **Always guard the call to** :code:`sim.run()` **with**
    :code:`if __name__ == '__main__':`. raypyng runs the simulations in parallel
-   through Python's :code:`multiprocessing`. On macOS (and Windows) the worker
-   processes are created with the :code:`spawn` start method, which **re-imports
-   your script** in every worker. Without the guard, each worker would execute
+   through Python's :code:`multiprocessing`. On macOS the worker processes are
+   created with the :code:`spawn` start method, which **re-imports your script**
+   in every worker. Without the guard, each worker would execute
    :code:`sim.run()` again on import, leading to runaway process creation and a
    :code:`RuntimeError`. On Linux the default start method is :code:`fork`, which
    does not re-import the script, so the guard is not strictly required there —
-   but adding it is harmless and makes the same script work on every platform.
+   but adding it is harmless and keeps the script working on both platforms.
 
    A complete script therefore looks like this:
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -15,14 +15,14 @@ Using the :code:`RMLFile` class it is possible to manipulate a beamline file pro
 
     from raypyng.rml import RMLFile
 
-    rml = RMLFile('rml/elisa.rml')
+    rml = RMLFile('rml/dipole_beamline.rml')
     print(rml)
 
 Output:
 
 .. code-block:: text
 
-    RMLFile('rml/elisa.rml', template='rml/elisa.rml')
+    RMLFile('rml/dipole_beamline.rml', template='rml/dipole_beamline.rml')
 
 The filename can be accessed with the :code:`filename` attribute:
 
@@ -34,14 +34,14 @@ Output:
 
 .. code-block:: text
 
-    rml/elisa.rml
+    rml/dipole_beamline.rml
 
 and the beamline is available under:
 
 .. code-block:: python
 
-    elisa = rml.beamline
-    print(elisa)
+    beamline = rml.beamline
+    print(beamline)
 
 Output:
 
@@ -54,7 +54,7 @@ the :code:`children()` method:
 
 .. code-block:: python
 
-    for i, oe in enumerate(elisa.children()):
+    for i, oe in enumerate(beamline.children()):
         print('OE ', i, ':', oe.resolvable_name())
 
 Output:
@@ -77,7 +77,7 @@ For instance, to print all the parameters of the Dipole:
 .. code-block:: python
 
     # print all the parameters of the Dipole
-    for param in elisa.Dipole.children():
+    for param in beamline.Dipole.children():
         print('Dipole param: ', param.id)
 
 Output:
@@ -116,13 +116,13 @@ Any parameter can be read and modified through its :code:`cdata` attribute:
 .. code-block:: python
 
     # read the current value
-    print(elisa.Dipole.photonEnergy.cdata)
+    print(beamline.Dipole.photonEnergy.cdata)
 
     # modify the value
-    elisa.Dipole.photonEnergy.cdata = str(2000)
+    beamline.Dipole.photonEnergy.cdata = str(2000)
 
     # read it back
-    print(elisa.Dipole.photonEnergy.cdata)
+    print(beamline.Dipole.photonEnergy.cdata)
 
 Output:
 
@@ -135,7 +135,7 @@ Once you are done with the modifications, you can save the rml file using the :c
 
 .. code-block:: python
 
-    rml.write('rml/new_elisa.rml')
+    rml.write('rml/new_dipole_beamline.rml')
 
 
 RAY-UI API
@@ -172,7 +172,7 @@ It is possible to load an rml file and trace it:
 
 .. code-block:: python
 
-    a.load('rml/elisa.rml')
+    a.load('rml/dipole_beamline.rml')
     a.trace(analyze=True)
 
 Export the files for the elements of interest:
@@ -192,7 +192,7 @@ instance if you change the photon energy, it will update the source flux):
 
 .. code-block:: python
 
-    a.save('rml/new_elisa')
+    a.save('rml/new_dipole_beamline')
 
 And finally we can quit the RAY-UI instance that we opened:
 
@@ -207,8 +207,8 @@ Perform Simulations
 --------------------
 raypyng is not able to create a beamline from scratch. To do so, use RAY-UI, 
 create a beamline, and save it. What you save is :code:`.rml` file, which you have to 
-pass as an argument to the :code:`Simulate` class. In the following example, we 
-use the file for a beamline called `elisa`, and the file is saved in :code:`rml/elisa.rml`. 
+pass as an argument to the :code:`Simulate` class. In the following example, we
+use a dipole beamline, saved in :code:`rml/dipole_beamline.rml`.
 On Linux, the :code:`hide` parameter can be set to :code:`True` only if `xvfb`
 is installed. On macOS xvfb is not needed and :code:`hide` is simply ignored, so
 it is safe to leave it set to :code:`True`.
@@ -216,10 +216,10 @@ it is safe to leave it set to :code:`True`.
 .. code-block:: python
 
     from raypyng import Simulate
-    rml_file = 'rml/elisa.rml'
+    rml_file = 'rml/dipole_beamline.rml'
 
     sim = Simulate(rml_file, hide=True)
-    elisa = sim.rml.beamline
+    beamline = sim.rml.beamline
 
 The elements of the beamline are now available as python objects, as well as 
 their properties. If working in ipython, tab autocompletion is available. 
@@ -228,13 +228,13 @@ For instance to access the source, a dipole in this case:
 .. code-block:: python
 
     # this is the dipole object
-    elisa.Dipole 
+    beamline.Dipole 
     # to acess its parameter, for instance, the photonFlux
-    elisa.Dipole.photonFlux
+    beamline.Dipole.photonFlux
     # to access the value 
-    elisa.Dipole.photonFlux.cdata
+    beamline.Dipole.photonFlux.cdata
     # to modify the value
-    elisa.Dipole.photonFlux.cdata = 10
+    beamline.Dipole.photonFlux.cdata = 10
 
 
 Independent and dependent parameters
@@ -275,8 +275,8 @@ aperture of the exit slit:
 
     # one key per dictionary -> both parameters are independent
     params = [
-        {elisa.Dipole.photonEnergy: energy},
-        {elisa.ExitSlit.totalHeight: SlitSize},
+        {beamline.Dipole.photonEnergy: energy},
+        {beamline.ExitSlit.totalHeight: SlitSize},
     ]
 
     # plug them into the Simulate class
@@ -332,8 +332,8 @@ the same length.
 
     # photonEnergy is independent; numberRays is dependent on it
     params = [
-        {elisa.Dipole.photonEnergy: energy, elisa.Dipole.numberRays: nrays},
-        {elisa.ExitSlit.totalHeight: SlitSize},
+        {beamline.Dipole.photonEnergy: energy, beamline.Dipole.numberRays: nrays},
+        {beamline.ExitSlit.totalHeight: SlitSize},
     ]
 
     sim.params = params
@@ -461,8 +461,8 @@ The exports are available for each optical element in the beamline, ImagePlanes 
 .. code-block:: python
 
     ## This must be a list of dictionaries
-    sim.exports  =  [{elisa.Dipole:['ScalarElementProperties']},
-                    {elisa.DetectorAtFocus:['ScalarBeamProperties']}
+    sim.exports  =  [{beamline.Dipole:['ScalarElementProperties']},
+                    {beamline.DetectorAtFocus:['ScalarBeamProperties']}
                     ]
 
 Finally, the simulations can be run using
@@ -491,16 +491,16 @@ Finally, the simulations can be run using
        from raypyng import Simulate
 
        if __name__ == '__main__':
-           rml_file = 'rml/elisa.rml'
+           rml_file = 'rml/dipole_beamline.rml'
            sim = Simulate(rml_file, hide=True)
-           elisa = sim.rml.beamline
+           beamline = sim.rml.beamline
 
            sim.params = [
-               {elisa.Dipole.photonEnergy: np.array([200, 400, 600])},
-               {elisa.ExitSlit.totalHeight: np.array([0.1])},
+               {beamline.Dipole.photonEnergy: np.array([200, 400, 600])},
+               {beamline.ExitSlit.totalHeight: np.array([0.1])},
            ]
            sim.simulation_name = 'test'
-           sim.exports = [{elisa.DetectorAtFocus: ['RawRaysOutgoing']}]
+           sim.exports = [{beamline.DetectorAtFocus: ['RawRaysOutgoing']}]
 
            sim.run(multiprocessing="auto", force=True)
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1,167 +1,204 @@
 Tutorial
 ********
 
-Manipulate an RML file 
+.. note::
+
+   Every code block in this tutorial is written so that it can be copied and
+   pasted directly into a Python script or interpreter. Program output, when
+   shown, is given in a separate block and is not meant to be pasted back in.
+
+Manipulate an RML file
 ========================
-Using the :code:`RMLFile` class it is possible to manupulate an beamline file produced by RAY-UI.
+Using the :code:`RMLFile` class it is possible to manipulate a beamline file produced by RAY-UI.
 
-.. code:: python
+.. code-block:: python
 
-  In [8]: from raypyng.rml import RMLFile
-   ...: rml = RMLFile('rml/elisa.rml')
-   ...: rml
-  Out[8]: RMLFile('rml/elisa.rml',template='rml/elisa.rml')
+    from raypyng.rml import RMLFile
 
-The filename can be accesed with the filename :code:`attribute`
+    rml = RMLFile('rml/elisa.rml')
+    print(rml)
 
-.. code:: python
+Output:
 
-  In [9]: rml.filename
-  Out[9]: 'rml/elisa.rml'
+.. code-block:: text
+
+    RMLFile('rml/elisa.rml', template='rml/elisa.rml')
+
+The filename can be accessed with the :code:`filename` attribute:
+
+.. code-block:: python
+
+    print(rml.filename)
+
+Output:
+
+.. code-block:: text
+
+    rml/elisa.rml
 
 and the beamline is available under:
 
-.. code:: python
-  
-  In [10]: elisa = rml.beamline
-  In [11]: elisa
-  Out[11]: XmlElement(name = beamline, attributes = {}, cdata = )
+.. code-block:: python
 
-It is possible to list all the element present in the beamlne using 
-the :code:`children()` method
+    elisa = rml.beamline
+    print(elisa)
 
-.. code:: python
+Output:
 
-  In [14]: for i, oe in enumerate(elisa.children()):
-    ...:     print('OE ',i, ':', oe.resolvable_name())
-    ...: 
-  OE  0 : Dipole
-  OE  1 : M1
-  OE  2 : PremirrorM2
-  OE  3 : PG
-  OE  4 : M3
-  OE  5 : ExitSlit
-  OE  6 : KB1
-  OE  7 : KB2
-  OE  8 : DetectorAtFocus
+.. code-block:: text
 
-In a similar way one can print all the available paramters of a certain element.
+    XmlElement(name = beamline, attributes = {}, cdata = )
+
+It is possible to list all the elements present in the beamline using
+the :code:`children()` method:
+
+.. code-block:: python
+
+    for i, oe in enumerate(elisa.children()):
+        print('OE ', i, ':', oe.resolvable_name())
+
+Output:
+
+.. code-block:: text
+
+    OE  0 : Dipole
+    OE  1 : M1
+    OE  2 : PremirrorM2
+    OE  3 : PG
+    OE  4 : M3
+    OE  5 : ExitSlit
+    OE  6 : KB1
+    OE  7 : KB2
+    OE  8 : DetectorAtFocus
+
+In a similar way one can print all the available parameters of a certain element.
 For instance, to print all the parameters of the Dipole:
 
-.. code:: python
+.. code-block:: python
 
-  In [15]: # print all the parameters of the Dipole
-    ...: for param in elisa.Dipole.children():
-    ...:     print('Dipole param: ', param.id)
-    ...: 
-  Dipole param:  numberRays
-  Dipole param:  sourceWidth
-  Dipole param:  sourceHeight
-  Dipole param:  verEbeamDiv
-  Dipole param:  horDiv
-  Dipole param:  electronEnergy
-  Dipole param:  electronEnergyOrientation
-  Dipole param:  bendingRadius
-  Dipole param:  alignmentError
-  Dipole param:  translationXerror
-  Dipole param:  translationYerror
-  Dipole param:  rotationXerror
-  Dipole param:  rotationYerror
-  Dipole param:  energyDistributionType
-  Dipole param:  photonEnergyDistributionFile
-  Dipole param:  photonEnergy
-  Dipole param:  energySpreadType
-  Dipole param:  energySpreadUnit
-  Dipole param:  energySpread
-  Dipole param:  sourcePulseType
-  Dipole param:  sourcePulseLength
-  Dipole param:  photonFlux
-  Dipole param:  worldPosition
-  Dipole param:  worldXdirection
-  Dipole param:  worldYdirection
-  Dipole param:  worldZdirection
+    # print all the parameters of the Dipole
+    for param in elisa.Dipole.children():
+        print('Dipole param: ', param.id)
 
-Any parameter can be modified in this way:
+Output:
 
-.. code:: python
+.. code-block:: text
 
-  In [17]: elisa.Dipole.photonEnergy.cdata
-  Out[17]: '1000'
+    Dipole param:  numberRays
+    Dipole param:  sourceWidth
+    Dipole param:  sourceHeight
+    Dipole param:  verEbeamDiv
+    Dipole param:  horDiv
+    Dipole param:  electronEnergy
+    Dipole param:  electronEnergyOrientation
+    Dipole param:  bendingRadius
+    Dipole param:  alignmentError
+    Dipole param:  translationXerror
+    Dipole param:  translationYerror
+    Dipole param:  rotationXerror
+    Dipole param:  rotationYerror
+    Dipole param:  energyDistributionType
+    Dipole param:  photonEnergyDistributionFile
+    Dipole param:  photonEnergy
+    Dipole param:  energySpreadType
+    Dipole param:  energySpreadUnit
+    Dipole param:  energySpread
+    Dipole param:  sourcePulseType
+    Dipole param:  sourcePulseLength
+    Dipole param:  photonFlux
+    Dipole param:  worldPosition
+    Dipole param:  worldXdirection
+    Dipole param:  worldYdirection
+    Dipole param:  worldZdirection
 
-  In [18]: elisa.Dipole.photonEnergy.cdata = str(2000)
+Any parameter can be read and modified through its :code:`cdata` attribute:
 
-  In [19]: elisa.Dipole.photonEnergy.cdata
-  Out[19]: 2000
+.. code-block:: python
 
-Once you are done with the modifications, you can save the rml file using the :code:`write()` method
+    # read the current value
+    print(elisa.Dipole.photonEnergy.cdata)
 
-.. code:: python
+    # modify the value
+    elisa.Dipole.photonEnergy.cdata = str(2000)
 
-  rml.write('rml/new_elisa.rml')
+    # read it back
+    print(elisa.Dipole.photonEnergy.cdata)
+
+Output:
+
+.. code-block:: text
+
+    1000
+    2000
+
+Once you are done with the modifications, you can save the rml file using the :code:`write()` method:
+
+.. code-block:: python
+
+    rml.write('rml/new_elisa.rml')
 
 
-RAY-UI API 
+RAY-UI API
 ===============
-Using the :code:`RayUIRunner` and the :code:`RayUIAPI` classes it is possible 
+Using the :code:`RayUIRunner` and the :code:`RayUIAPI` classes it is possible
 to interact with RAY-UI directly from python.
 
-.. code:: python
+.. code-block:: python
 
-  In [1]: import os
-   ...: import time
-   ...: from raypyng.runner import RayUIRunner, RayUIAPI
-   ...: 
-   ...: r = RayUIRunner(ray_path=None, hide=True)
-   ...: a = RayUIAPI(r)
+    from raypyng.runner import RayUIRunner, RayUIAPI
 
-  In [2]: r.run()
-  Out[2]: <raypyng.runner.RayUIRunner at 0x7effd8f53b50>
+    r = RayUIRunner(ray_path=None, hide=True)
+    a = RayUIAPI(r)
+
+    # start the RAY-UI process
+    r.run()
 
 Once an instance of RAY-UI is running, we can confirm that it is running
-and we can ask the :code:`pid`
+and we can ask for its :code:`pid`:
 
-.. code:: python
+.. code-block:: python
 
-  In [3]: r.isrunning
-  Out[3]: True
+    print(r.isrunning)
+    print(r.pid)
 
-  In [4]: r.pid
-  Out[4]: 20742
+Output:
 
-It is possible to load an rml file and trace it
+.. code-block:: text
 
-.. code:: python
+    True
+    20742
 
-  In [5]: a.load('rml/elisa.rml')
-   ...: 
-  Out[5]: True
+It is possible to load an rml file and trace it:
 
-  In [6]: a.trace(analyze=True)
-    ...: 
-  Out[6]: True
- 
+.. code-block:: python
+
+    a.load('rml/elisa.rml')
+    a.trace(analyze=True)
+
 Export the files for the elements of interest:
 
-.. code:: python
+.. code-block:: python
 
-  In [7]: a.export("Dipole,DetectorAtFocus", "RawRaysOutgoing", '/home/simone/Documents/RAYPYNG/raypyng/examples', 'test_export')
-   ...: 
-  Out[7]: True
+    a.export(
+        "Dipole,DetectorAtFocus",
+        "RawRaysOutgoing",
+        '/home/simone/Documents/RAYPYNG/raypyng/examples',
+        'test_export',
+    )
 
-Save the rml file used for the simulation (this is useful because RAY-UI 
-when it traces the beamline it updates the RML files with the latest parameters: for
-instance if you change the photon energy, it will update the source flux)
+Save the rml file used for the simulation (this is useful because when RAY-UI
+traces the beamline it updates the RML file with the latest parameters: for
+instance if you change the photon energy, it will update the source flux):
 
-.. code:: python 
+.. code-block:: python
 
-  In [8]: a.save('rml/new_elisa')
-  Out[8]: True
+    a.save('rml/new_elisa')
 
 And finally we can quit the RAY-UI instance that we opened:
 
-.. code:: python
+.. code-block:: python
 
-  In [9]: a.quit()
+    a.quit()
 
 Simulations 
 ===============
@@ -200,45 +237,148 @@ For instance to access the source, a dipole in this case:
     elisa.Dipole.photonFlux.cdata = 10
 
 
-To perform a simulation, any number of parameters can be varied. 
-For instance, one can vary the photon energy of the source, and set a 
-a certain aperture of the exit slits:
+Independent and dependent parameters
+-------------------------------------
+
+To perform a simulation, any number of parameters can be varied. The values to
+scan are passed to :code:`sim.params` as a **list of dictionaries**. Each
+dictionary describes one *block* of parameters, and the way parameters combine
+depends on whether they are **independent** or **dependent**.
+
+The rules, in the abstract:
+
+- **Each dictionary in the list contributes exactly one independent
+  parameter: its first key.** Independent parameters are scanned against each
+  other as a full grid (the Cartesian product of their value lists).
+- **Any additional key in the same dictionary is a dependent parameter.** A
+  dependent parameter is *coupled* to the independent parameter of its
+  dictionary: it does not add a new dimension to the grid, it simply advances
+  together with its independent partner. Its value list must therefore have the
+  **same length** as the independent one.
+- **The total number of simulations is the product of the lengths of the
+  independent parameters only.** Dependent parameters never increase this count.
+
+Independent parameters (a grid)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In the simplest case every dictionary has a single key, so every parameter is
+independent. For instance, to scan the photon energy of the source against the
+aperture of the exit slit:
 
 .. code-block:: python
-    
-    # define the values of the parameters to scan 
-    energy    = np.arange(200, 7201,250)
-    SlitSize  = np.array([0.1])
 
-    # define a list of dictionaries with the parameters to scan
-    params = [  
-                {elisa.Dipole.photonEnergy:energy}, 
-                {elisa.ExitSlit.totalHeight:SlitSize}
-            ]
+    import numpy as np
 
-    #and then plug them into the Simulation class
-    sim.params=params
+    # define the values of the parameters to scan
+    energy   = np.array([200, 400])
+    SlitSize = np.array([0.1, 0.5, 0.9])
 
-It is also possible to define coupled parameters. If for instance, one wants 
-to increase the number of rays with the photon energy
+    # one key per dictionary -> both parameters are independent
+    params = [
+        {elisa.Dipole.photonEnergy: energy},
+        {elisa.ExitSlit.totalHeight: SlitSize},
+    ]
+
+    # plug them into the Simulate class
+    sim.params = params
+
+This produces ``2 x 3 = 6`` simulations, one for every combination of the two
+parameters. The **last** parameter in the list varies fastest:
+
+.. list-table:: 6 simulations: full grid of two independent parameters
+   :header-rows: 1
+   :widths: 12 30 30
+
+   * - sim #
+     - ``photonEnergy`` (independent)
+     - ``totalHeight`` (independent)
+   * - 0
+     - 200
+     - 0.1
+   * - 1
+     - 200
+     - 0.5
+   * - 2
+     - 200
+     - 0.9
+   * - 3
+     - 400
+     - 0.1
+   * - 4
+     - 400
+     - 0.5
+   * - 5
+     - 400
+     - 0.9
+
+Dependent (coupled) parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+It is also possible to define coupled parameters. For instance, one may want to
+increase the number of rays together with the photon energy, so that every
+energy point is simulated with its own ray count. To couple two parameters,
+place them in the **same dictionary**: the first key is the independent
+parameter, the following keys are dependent on it and must have value lists of
+the same length.
 
 .. code-block:: python
-    
-    # define the values of the parameters to scan 
-    energy    = np.arange(200, 7201,250)
-    nrays     = energy*100
-    SlitSize  = np.array([0.1])
 
-    # define a list of dictionaries with the parameters to scan
-    params = [  
-                {elisa.Dipole.photonEnergy:energy, elisa.Dipole.numberRays:nrays}, 
-                {elisa.ExitSlit.totalHeight:SlitSize}
-            ]
+    import numpy as np
 
-    #and then plug them into the Simulation class
-    sim.params=params
+    # energy and nrays must have the same length: they are coupled
+    energy   = np.array([200, 400, 600])
+    nrays    = np.array([20, 40, 60])
+    SlitSize = np.array([0.1])
 
-The simulations files and the results will be saved in a folder called `RAYPy_simulation_` 
+    # photonEnergy is independent; numberRays is dependent on it
+    params = [
+        {elisa.Dipole.photonEnergy: energy, elisa.Dipole.numberRays: nrays},
+        {elisa.ExitSlit.totalHeight: SlitSize},
+    ]
+
+    sim.params = params
+
+Here ``numberRays`` does not multiply the number of simulations: there are
+``3 x 1 = 3`` simulations, and at each one ``numberRays`` takes the value paired
+with the current ``photonEnergy``:
+
+.. list-table:: 3 simulations: ``numberRays`` coupled to ``photonEnergy``
+   :header-rows: 1
+   :widths: 10 26 26 26
+
+   * - sim #
+     - ``photonEnergy`` (independent)
+     - ``numberRays`` (dependent)
+     - ``totalHeight`` (independent)
+   * - 0
+     - 200
+     - 20
+     - 0.1
+   * - 1
+     - 400
+     - 40
+     - 0.1
+   * - 2
+     - 600
+     - 60
+     - 0.1
+
+More than one parameter can be coupled to the same independent parameter by
+adding further keys to the dictionary (all with value lists of the same
+length). For example ``{photonEnergy: energy, numberRays: nrays, energySpread:
+spread}`` keeps ``numberRays`` and ``energySpread`` both locked to
+``photonEnergy``.
+
+.. note::
+
+   A dependent parameter advances together with the **fastest-varying** scan
+   dimension, which is the **last** independent parameter in the list. When you
+   mix a coupled block with other independent parameters that have more than one
+   value, put the coupled block **last** so the coupling stays aligned with its
+   partner. In the example above this is automatic, because the only other
+   independent parameter (``totalHeight``) has a single value.
+
+The simulations files and the results will be saved in a folder called `RAYPy_simulation_`
 and a name of your choice, that can be set. This folder will be saved, by default, 
 in the folder where the program is executed, but it can eventually be modified
 
@@ -247,9 +387,9 @@ in the folder where the program is executed, but it can eventually be modified
     sim.simulation_folder = '/home/raypy/Documents/simulations'
     sim.simulation_name = 'test'
 
-This will create a simulation folder with the following path and name
+This will create a simulation folder with the following path and name:
 
-.. code-block:: python
+.. code-block:: text
 
     /home/raypy/Documents/simulations/RAYPy_simulation_test
 
@@ -273,24 +413,29 @@ In this case, the following files are available to export:
 .. code-block:: python
 
     print(sim.possible_exports)
-    > ['AnglePhiDistribution',
-    > 'AnglePsiDistribution',
-    > 'BeamPropertiesPlotSnapshot',
-    > 'EnergyDistribution',
-    > 'FootprintAbsorbedRays',
-    > 'FootprintAllRays',
-    > 'FootprintOutgoingRays',
-    > 'FootprintPlotSnapshot',
-    > 'FootprintWastedRays',
-    > 'IntensityPlotSnapshot',
-    > 'IntensityX',
-    > 'IntensityYZ',
-    > 'PathlengthDistribution',
-    > 'RawRaysBeam',
-    > 'RawRaysIncoming',
-    > 'RawRaysOutgoing',
-    > 'ScalarBeamProperties',
-    > 'ScalarElementProperties']
+
+Output:
+
+.. code-block:: text
+
+    ['AnglePhiDistribution',
+     'AnglePsiDistribution',
+     'BeamPropertiesPlotSnapshot',
+     'EnergyDistribution',
+     'FootprintAbsorbedRays',
+     'FootprintAllRays',
+     'FootprintOutgoingRays',
+     'FootprintPlotSnapshot',
+     'FootprintWastedRays',
+     'IntensityPlotSnapshot',
+     'IntensityX',
+     'IntensityYZ',
+     'PathlengthDistribution',
+     'RawRaysBeam',
+     'RawRaysIncoming',
+     'RawRaysOutgoing',
+     'ScalarBeamProperties',
+     'ScalarElementProperties']
 
 To let raypyng analyze the results set:
 
@@ -299,12 +444,17 @@ To let raypyng analyze the results set:
     sim.analyze = False # don't let RAY-UI analyze the results
     sim.raypyng_analysis=True # let raypyng analyze the results
 
-In this case, only these exports are possible
+In this case, only these exports are possible:
 
 .. code-block:: python
 
     print(sim.possible_exports_without_analysis)
-    > ['RawRaysIncoming', 'RawRaysOutgoing']
+
+Output:
+
+.. code-block:: text
+
+    ['RawRaysIncoming', 'RawRaysOutgoing']
 
 The exports are available for each optical element in the beamline, ImagePlanes included, and can be set like this:
 
@@ -320,6 +470,39 @@ Finally, the simulations can be run using
 .. code-block:: python
 
     sim.run(multiprocessing="auto", force=True)
+
+.. important::
+
+   **Always guard the call to** :code:`sim.run()` **with**
+   :code:`if __name__ == '__main__':`. raypyng runs the simulations in parallel
+   through Python's :code:`multiprocessing`. On macOS (and Windows) the worker
+   processes are created with the :code:`spawn` start method, which **re-imports
+   your script** in every worker. Without the guard, each worker would execute
+   :code:`sim.run()` again on import, leading to runaway process creation and a
+   :code:`RuntimeError`. On Linux the default start method is :code:`fork`, which
+   does not re-import the script, so the guard is not strictly required there —
+   but adding it is harmless and makes the same script work on every platform.
+
+   A complete script therefore looks like this:
+
+   .. code-block:: python
+
+       import numpy as np
+       from raypyng import Simulate
+
+       if __name__ == '__main__':
+           rml_file = 'rml/elisa.rml'
+           sim = Simulate(rml_file, hide=True)
+           elisa = sim.rml.beamline
+
+           sim.params = [
+               {elisa.Dipole.photonEnergy: np.array([200, 400, 600])},
+               {elisa.ExitSlit.totalHeight: np.array([0.1])},
+           ]
+           sim.simulation_name = 'test'
+           sim.exports = [{elisa.DetectorAtFocus: ['RawRaysOutgoing']}]
+
+           sim.run(multiprocessing="auto", force=True)
 
 where the `multiprocessing` parameter can be:
 
@@ -446,21 +629,238 @@ This file:
 This keeps existing scripts based on exact CSV column names compatible, while still making the
 units available in a machine-readable format.
 
+Providing your own flux and efficiency tables
+---------------------------------------------
+
+RAY-UI traces the *geometry* of the beamline very well, but the **absolute
+photon flux** it assigns to a source, and the efficiency of optical elements it
+cannot model (for instance a grating coated with a multilayer), are often better
+known from external calculations or measurements. raypyng lets you feed in two
+kinds of tabulated data at simulation runtime, which are then used by the
+analysis to produce more realistic numbers:
+
+- an **undulator flux table** (:code:`sim.undulator_table`), and
+- a **general efficiency table** (:code:`sim.efficiency`).
+
+Both are passed as pandas DataFrames before calling :code:`sim.run()`, and both
+only affect the *flux-related* analyzed columns. The geometric quantities
+(focus FWHM, divergence, bandwidth, beam centre) are unchanged.
+
+Undulator flux table
+^^^^^^^^^^^^^^^^^^^^^
+
+When the source is an undulator, the flux emitted per harmonic as a function of
+photon energy is usually computed with a dedicated code (e.g. WAVE or SPECTRA).
+You can supply that spectrum as a table; raypyng then **ignores the source flux
+estimated by RAY-UI and uses your tabulated flux instead**.
+
+The table must be a DataFrame with an **even number of columns, grouped in
+energy/flux pairs, one pair per odd harmonic**, named exactly
+``Energy1[eV]``, ``Photons1``, ``Energy3[eV]``, ``Photons3``,
+``Energy5[eV]``, ``Photons5``, … (the bundled example
+``examples/undulator/undulator_harmonics_energy_photons.csv`` follows this
+format). The source in the ``.rml`` must be a real undulator: it **cannot** be a
+``Dipole`` or an ``Undulator File`` source.
+
+.. code-block:: python
+
+    import pandas as pd
+
+    undulator = pd.read_csv('undulator/undulator_harmonics_energy_photons.csv')
+    sim.undulator_table = undulator
+
+    sim.run(multiprocessing="auto", force=True)
+
+**Impact on the results.** This is the important part. Without a table, raypyng
+writes a single set of flux columns and computes the flux at the detector as
+
+.. code-block:: text
+
+    PhotonFlux = SourcePhotonFlux (from RAY-UI) / 100 * PercentageRaysSurvived
+
+With an undulator table, the source flux no longer comes from RAY-UI. For each
+simulated photon energy and **each harmonic** :code:`h`, raypyng linearly
+interpolates your tabulated flux ``Photons{h}`` and scales it by the fraction of
+rays that survived the beamline:
+
+.. code-block:: text
+
+    PhotonFlux{h} = interp(energy, Energy{h}[eV], Photons{h}) * PercentageRaysSurvived / 100
+
+Consequently the analyzed output gains **one set of flux columns per harmonic**
+instead of a single one. For a table with harmonics 1, 3 and 5 you get, for
+example, ``PhotonFlux1``, ``PhotonFlux3``, ``PhotonFlux5``, and likewise
+``FluxPerMilPerBwAbs1/3/5``, ``AXUVCurrentAmp1/3/5`` and
+``GaAsPCurrentAmp1/3/5``. In short: the absolute flux and the diode currents are
+driven entirely by your table (per harmonic), while the ray tracing only
+contributes the transmission and the geometry.
+
+General efficiency table
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The efficiency table covers the second case: an optical element whose
+energy-dependent efficiency RAY-UI does not compute — the typical example being
+a **grating coated with a multilayer**, but it applies to any element for which
+you have your own tabulated efficiency (reflectivity, diffraction efficiency,
+filter transmission, …).
+
+The table must be a DataFrame with two columns, ``Efficiency`` and
+``Energy[eV]``:
+
+.. code-block:: python
+
+    import pandas as pd
+
+    eff = pd.DataFrame({
+        "Efficiency": [0.9, 0.8, 0.7],
+        "Energy[eV]": [100, 200, 300],
+    })
+    sim.efficiency = eff
+
+    sim.run(multiprocessing="auto", force=True)
+
+**Impact on the results.** The efficiency is linearly interpolated at each
+simulated photon energy and multiplies the transmission:
+
+.. code-block:: text
+
+    PercentageRaysSurvived = (rays_survived / rays_source) * 100 * efficiency(energy)
+
+Because every flux-related quantity (``PhotonFlux``, ``FluxPerMilPerBwPerc``,
+``FluxPerMilPerBwAbs``, the diode currents) is derived from
+``PercentageRaysSurvived``, all of them are scaled down by the same efficiency
+factor. The number of columns does not change; only their values are reduced to
+account for the element you modelled externally.
+
+.. note::
+
+   The two tables are independent and can be used together. The efficiency
+   table scales the transmission; the undulator table sets the absolute source
+   flux per harmonic. Neither affects the focus size, divergence, bandwidth or
+   beam-centre columns, which depend only on the traced geometry.
+
+Working with the results
+------------------------
+
+.. note::
+
+   This section is intentionally minimal for now and will be expanded.
+
+When raypyng performs the analysis, the most convenient output is the combined
+recap file written in the simulation folder, one per exported element, for
+example ``DetectorAtFocus_RawRaysOutgoing.csv``. Each row is one simulation; the
+first columns are the scanned input parameters (taken from ``looper.csv``) and
+the remaining columns are the analyzed quantities listed above.
+
+It is a plain CSV, so it can be loaded directly with pandas:
+
+.. code-block:: python
+
+    import pandas as pd
+
+    df = pd.read_csv('RAYPy_Simulation_test/DetectorAtFocus_RawRaysOutgoing.csv')
+
+    # the scanned input parameters are columns named "<element>.<parameter>"
+    energy = df['Dipole.photonEnergy']
+
+    # the analyzed outputs are columns such as these
+    flux = df['PhotonFlux']
+    transmission = df['PercentageRaysSurvived']
+    h_fwhm = df['HorizontalFocusFWHM']
+
+    print(df.columns.tolist())
+
+You can then filter, plot, or further process the DataFrame as usual. A complete
+plotting example is available in `eval_permil.py
+<https://github.com/hz-b/raypyng/blob/main/examples/eval_permil.py>`_.
+
 Recipes
 ========
-raypyng provides some recipes to make simulations, 
-that simplify the syntax in the script. 
+raypyng provides some recipes to make simulations,
+that simplify the syntax in the script.
 Two recipes are provided, one to make `Resolving Power
-<https://github.com/hz-b/raypyng/blob/main/examples/example_simulation_RP.py>`_ simulations, 
+<https://github.com/hz-b/raypyng/blob/main/examples/simulation_recipee_ResolvinPower.py>`_ simulations,
 one to make `Flux
-<https://github.com/hz-b/raypyng/blob/main/examples/example_simulation_Flux.py>`_
-simulations. 
+<https://github.com/hz-b/raypyng/blob/main/examples/simulation_recipee_Flux.py>`_
+simulations.
 
 
-List of available examples 
+List of available examples
 ===========================
-Examples are available at the following link: Examples are available at the following link: `raypyng examples <https://github.com/hz-b/raypyng/blob/main/examples>`_.
+All examples live in the `examples folder
+<https://github.com/hz-b/raypyng/blob/main/examples>`_ of the repository. A short
+description of each one follows.
 
+Simulation examples
+-------------------
+These scripts run a beamline scan end to end.
+
+- `simulation_raypyng.py
+  <https://github.com/hz-b/raypyng/blob/main/examples/simulation_raypyng.py>`_ —
+  basic simulation: scan the photon energy and exit-slit aperture of a dipole
+  beamline and let **raypyng** analyze the exported rays.
+- `simulation_analysis_by_RAY-UI.py
+  <https://github.com/hz-b/raypyng/blob/main/examples/simulation_analysis_by_RAY-UI.py>`_ —
+  the same kind of scan, but letting **RAY-UI** perform the analysis
+  (:code:`ScalarBeamProperties` / :code:`ScalarElementProperties`).
+- `simulation_permil.py
+  <https://github.com/hz-b/raypyng/blob/main/examples/simulation_permil.py>`_ —
+  flux and bandwidth per 0.1% bandwidth, scanning energy for two grating line
+  densities.
+- `simulation_external_undulator_flux_table.py
+  <https://github.com/hz-b/raypyng/blob/main/examples/simulation_external_undulator_flux_table.py>`_ —
+  undulator source whose flux is taken from an external flux table
+  (:code:`sim.undulator_table`).
+- `simulation_multilayer_monochromator_efficiency.py
+  <https://github.com/hz-b/raypyng/blob/main/examples/simulation_multilayer_monochromator_efficiency.py>`_ —
+  fold an externally computed monochromator efficiency into the results
+  (:code:`sim.efficiency`).
+- `simulation_waveFiles.py
+  <https://github.com/hz-b/raypyng/blob/main/examples/simulation_waveFiles.py>`_ —
+  drive an Undulator from external WAVE ray files via the :code:`undulatorFile`
+  parameter.
+- `simulation_slope_errors.py
+  <https://github.com/hz-b/raypyng/blob/main/examples/simulation_slope_errors.py>`_ —
+  scan the meridional/sagittal slope errors of the mirrors one at a time.
+- `simulation_save_space.py
+  <https://github.com/hz-b/raypyng/blob/main/examples/simulation_save_space.py>`_ —
+  same scan as the basic example but deleting raw-ray files and round folders to
+  save disk space (:code:`remove_rawrays`, :code:`remove_round_folders`).
+- `simulation_recipee_Flux.py
+  <https://github.com/hz-b/raypyng/blob/main/examples/simulation_recipee_Flux.py>`_ —
+  run a flux scan with the ready-made :code:`Flux` recipe.
+- `simulation_recipee_ResolvinPower.py
+  <https://github.com/hz-b/raypyng/blob/main/examples/simulation_recipee_ResolvinPower.py>`_ —
+  run a resolving-power scan with the ready-made :code:`ResolvingPower` recipe.
+
+Building-block and post-processing examples
+-------------------------------------------
+These scripts show individual pieces of raypyng without running a full scan.
+
+- `example_rml.py
+  <https://github.com/hz-b/raypyng/blob/main/examples/example_rml.py>`_ —
+  open an RML file, list its elements and parameters, and modify a value.
+- `example_runner.py
+  <https://github.com/hz-b/raypyng/blob/main/examples/example_runner.py>`_ —
+  drive RAY-UI directly through :code:`RayUIRunner` / :code:`RayUIAPI`
+  (load, trace, export, quit).
+- `example_waveHelper.py
+  <https://github.com/hz-b/raypyng/blob/main/examples/example_waveHelper.py>`_ —
+  use :code:`WaveHelper` to inspect a WAVE folder and list the available
+  undulator energies/files.
+- `example_beamwaist.py
+  <https://github.com/hz-b/raypyng/blob/main/examples/example_beamwaist.py>`_ —
+  trace and plot the beam waist along the beamline with :code:`PlotBeamwaist`.
+- `dipole.py
+  <https://github.com/hz-b/raypyng/blob/main/examples/dipole.py>`_ —
+  compute and plot a dipole source spectrum from its magnetic field with the
+  standalone :code:`Dipole` class (no RAY-UI needed).
+- `diodes.py
+  <https://github.com/hz-b/raypyng/blob/main/examples/diodes.py>`_ —
+  convert a photon flux into a diode current for AXUV and GaAsP diodes.
+- `eval_permil.py
+  <https://github.com/hz-b/raypyng/blob/main/examples/eval_permil.py>`_ —
+  post-process and plot the results produced by ``simulation_permil.py``.
 
   
   

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -20,11 +20,11 @@ class TestAnalyze(unittest.TestCase):
             shutil.rmtree(dirpath)
 
         this_file_dir = os.path.dirname(os.path.realpath(__file__))
-        rml_file = os.path.join(this_file_dir, "rml/elisa.rml")
+        rml_file = os.path.join(this_file_dir, "rml/dipole.rml")
 
         sim = Simulate(rml_file, hide=True)
 
-        elisa = sim.rml.beamline
+        beamline = sim.rml.beamline
 
         # define the values of the parameters to scan
         energy = np.arange(200, 7201, 1000)
@@ -35,12 +35,12 @@ class TestAnalyze(unittest.TestCase):
         # define a list of dictionaries with the parameters to scan
         params = [
             # set two parameters: "alpha" and "beta" in a dependent way.
-            {elisa.Dipole.photonEnergy: energy},
+            {beamline.Dipole.photonEnergy: energy},
             # set a range of  values
-            {elisa.ExitSlit.totalHeight: SlitSize},
+            {beamline.ExitSlit.totalHeight: SlitSize},
             # set values
-            {elisa.PG.cFactor: cff},
-            {elisa.Dipole.numberRays: nrays},
+            {beamline.PG.cFactor: cff},
+            {beamline.Dipole.numberRays: nrays},
         ]
 
         # and then plug them into the Simulation class
@@ -55,8 +55,8 @@ class TestAnalyze(unittest.TestCase):
         sim.analyze = True  # let RAY-UI analyze the results
         ## This must be a list of dictionaries
         sim.exports = [
-            {elisa.Dipole: ["ScalarElementProperties"]},
-            {elisa.DetectorAtFocus: ["ScalarBeamProperties"]},
+            {beamline.Dipole: ["ScalarElementProperties"]},
+            {beamline.DetectorAtFocus: ["ScalarBeamProperties"]},
         ]
         result = sim.run(multiprocessing=5, force=True)
         self.assertTrue(result)

--- a/tests/test_no_analyze.py
+++ b/tests/test_no_analyze.py
@@ -20,11 +20,11 @@ class TestNoAnalyze(unittest.TestCase):
             shutil.rmtree(dirpath)
 
         this_file_dir = os.path.dirname(os.path.realpath(__file__))
-        rml_file = os.path.join(this_file_dir, "rml/elisa.rml")
+        rml_file = os.path.join(this_file_dir, "rml/dipole.rml")
 
         sim = Simulate(rml_file, hide=True)
 
-        elisa = sim.rml.beamline
+        beamline = sim.rml.beamline
 
         # define the values of the parameters to scan
         energy = np.arange(200, 7201, 1000)
@@ -35,12 +35,12 @@ class TestNoAnalyze(unittest.TestCase):
         # define a list of dictionaries with the parameters to scan
         params = [
             # set two parameters: "alpha" and "beta" in a dependent way.
-            {elisa.Dipole.photonEnergy: energy},
+            {beamline.Dipole.photonEnergy: energy},
             # set a range of  values
-            {elisa.ExitSlit.totalHeight: SlitSize},
+            {beamline.ExitSlit.totalHeight: SlitSize},
             # set values
-            {elisa.PG.cFactor: cff},
-            {elisa.Dipole.numberRays: nrays},
+            {beamline.PG.cFactor: cff},
+            {beamline.Dipole.numberRays: nrays},
         ]
 
         # and then plug them into the Simulation class
@@ -57,8 +57,8 @@ class TestNoAnalyze(unittest.TestCase):
 
         ## This must be a list of dictionaries
         sim.exports = [
-            {elisa.Dipole: "RawRaysOutgoing"},
-            {elisa.DetectorAtFocus: ["RawRaysOutgoing"]},
+            {beamline.Dipole: "RawRaysOutgoing"},
+            {beamline.DetectorAtFocus: ["RawRaysOutgoing"]},
         ]
 
         # uncomment to run the simulations

--- a/tests/test_simulation_class.py
+++ b/tests/test_simulation_class.py
@@ -12,30 +12,30 @@ class TestAnalyze(unittest.TestCase):
     def test_1_turn_reflectivity_on(self):
 
         this_file_dir = os.path.dirname(os.path.realpath(__file__))
-        rml_file = os.path.join(this_file_dir, "rml/elisa.rml")
+        rml_file = os.path.join(this_file_dir, "rml/dipole.rml")
 
         sim = Simulate(rml_file, hide=True)
 
-        elisa = sim.rml.beamline
+        beamline = sim.rml.beamline
 
         sim.reflectivity(True)
 
-        for oe in elisa.children():
+        for oe in beamline.children():
             if hasattr(oe, "reflectivityType"):
                 self.assertEqual("1", oe.reflectivityType.cdata)
 
     def test_0_turn_reflectivity_off(self):
 
         this_file_dir = os.path.dirname(os.path.realpath(__file__))
-        rml_file = os.path.join(this_file_dir, "rml/elisa.rml")
+        rml_file = os.path.join(this_file_dir, "rml/dipole.rml")
 
         sim = Simulate(rml_file, hide=True)
 
-        elisa = sim.rml.beamline
+        beamline = sim.rml.beamline
 
         sim.reflectivity(False)
 
-        for oe in elisa.children():
+        for oe in beamline.children():
             if hasattr(oe, "reflectivityType"):
                 self.assertEqual("0", oe.reflectivityType.cdata)
 


### PR DESCRIPTION
## Summary

A documentation overhaul on top of the merged macOS work, plus a couple of related correctness fixes.

### Tutorial & guides
- Converted all tutorial / how-to code from IPython transcripts (`In[]`/`Out[]`) to copy-pasteable code blocks, with program output shown separately.
- Added an **Independent vs dependent parameters** section with an abstract explanation and verified output tables (grid vs coupled).
- Added a **Quickstart** with a complete minimal script on the index page.
- Added a minimal **Working with the results** section (load the recap CSV with pandas).
- Added a **Providing your own flux and efficiency tables** section documenting `sim.undulator_table` (per-harmonic flux, replaces RAY-UI source flux) and `sim.efficiency` (scales transmission), and their impact on the output columns.
- Gave each entry in **List of available examples** a one-line description; fixed two broken recipe links.

### Platform / OS support
- Documented the `if __name__ == '__main__':` guard required by macOS `spawn`.
- Stated clearly that **simulations do not run on Windows** (RAY-UI has no background mode there) and removed earlier contradictory "macOS and Windows" wording.
- Added a **Troubleshooting / FAQ** page wired into the toctree.

### Fixes
- Dropped the legacy `elisa` beamline name throughout the docs in favour of the shipped `dipole_beamline.rml` (identical structure, so shown output is unchanged).
- **Bug fix:** `tests/test_analyze.py`, `test_no_analyze.py`, and `test_simulation_class.py` referenced `tests/rml/elisa.rml`, which does not exist, so they failed to load. Pointed them at `tests/rml/dipole.rml` (identical structure). `test_simulation_class.py` passes locally.
- Fixed the bare `docs` `.gitignore` rule that was silently excluding new docs source files; keep generated `docs/images` ignored explicitly.

## Notes for the reviewer
- One `elisa` reference remains in `tests/test_mutable_config_properties.py` → `tests/test_bug/rml/elisa.rml`; that fixture actually exists and the test works, so it was left as-is.
- Pre-existing (unrelated) latent bug spotted: `tests/test_no_analyze.py` defines `test_round_folders_rml` and `test_input_Dipole_file` twice each, so the earlier definitions are shadowed. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)