### PR TITLE
Fix example path handling and missing __main__ guards

### DIFF
--- a/examples/example_rml.py
+++ b/examples/example_rml.py
@@ -1,34 +1,30 @@
 from raypyng.rml import RMLFile
 import os
 
-
-
-this_file_dir=os.path.dirname(os.path.realpath(__file__))
-rml_file = os.path.join(this_file_dir,'rml/dipole_beamline.rml')
+this_file_dir = os.path.dirname(os.path.realpath(__file__))
+rml_file = os.path.join(this_file_dir, "rml/dipole_beamline.rml")
 
 rml = RMLFile(rml_file)
 
 
-print('rml type:', type(rml))
+print("rml type:", type(rml))
 
-print('rml.filename:', rml.filename)
+print("rml.filename:", rml.filename)
 
-print('rml.beamline type:', type(rml.beamline))
+print("rml.beamline type:", type(rml.beamline))
 
 # print all the elements in the beamline
 for oe in rml.beamline.children():
-    print('OE:', oe.resolvable_name())
+    print("OE:", oe.resolvable_name())
 
 # print all the parameters of the Dipole
 for param in rml.beamline.Dipole.children():
-    print('Dipole param: ', param.id)
+    print("Dipole param: ", param.id)
 
 # Modify a paramer of the Diple:
-print('Dipole photon energy: ',rml.beamline.Dipole.photonEnergy.cdata)
+print("Dipole photon energy: ", rml.beamline.Dipole.photonEnergy.cdata)
 rml.beamline.Dipole.photonEnergy.cdata = str(2000)
-print('New Dipole photon energy: ',rml.beamline.Dipole.photonEnergy.cdata)
+print("New Dipole photon energy: ", rml.beamline.Dipole.photonEnergy.cdata)
 
 # Save the rml file with a new name
-rml.write('rml/new_dipole_beamline.rml')
-
-        
+rml.write(os.path.join(this_file_dir, "rml/new_dipole_beamline.rml"))

--- a/examples/example_runner.py
+++ b/examples/example_runner.py
@@ -2,36 +2,31 @@ import os
 import time
 from raypyng.runner import RayUIRunner, RayUIAPI
 
-r = RayUIRunner(ray_path=None, hide=True)
-a = RayUIAPI(r)
+if __name__ == "__main__":
+    this_file_dir = os.path.dirname(os.path.realpath(__file__))
 
+    r = RayUIRunner(ray_path=None, hide=True)
+    a = RayUIAPI(r)
 
-# Start a RAY-UI instance
-r.run()
+    # Start a RAY-UI instance
+    r.run()
 
-# Confirm that it is running and print the process id
-print('Confirm that RAY-UI is running:', r.isrunning)
-print("RAY-UI is running with pid", r.pid)
+    # Confirm that it is running and print the process id
+    print("Confirm that RAY-UI is running:", r.isrunning)
+    print("RAY-UI is running with pid", r.pid)
 
-# load an rml file
-print("Loading rml file")
-a.load('rml/dipole_beamline.rml')
+    # load an rml file
+    print("Loading rml file")
+    a.load(os.path.join(this_file_dir, "rml/dipole_beamline.rml"))
 
-print("Trace...")
-a.trace(analyze=True)
+    print("Trace...")
+    a.trace(analyze=True)
 
-print("Exporting")
-this_file_dir=os.path.dirname(os.path.realpath(__file__))
-a.export("Dipole,DetectorAtFocus", "RawRaysOutgoing", this_file_dir, 'test_export')
+    print("Exporting")
+    a.export("Dipole,DetectorAtFocus", "RawRaysOutgoing", this_file_dir, "test_export")
 
-
-print("Killing the RAY-UI process")
-r.kill()
-# sometime it takes a while to kill the process
-time.sleep(2)
-print('Confirm that RAY-UI is running:', r.isrunning)
-
-
-
-
-        
+    print("Killing the RAY-UI process")
+    r.kill()
+    # sometime it takes a while to kill the process
+    time.sleep(2)
+    print("Confirm that RAY-UI is running:", r.isrunning)

--- a/examples/simulation_slope_errors.py
+++ b/examples/simulation_slope_errors.py
@@ -1,7 +1,10 @@
+import os
+
 import numpy as np
 from raypyng import Simulate
 
-if __name__ == '__main__':
+if __name__ == "__main__":
+
     def make_slopes_params(param_dict):
         total_steps = 1 + sum(len(v) for v in param_dict.values())
         scan_dict = {k: [0] * total_steps for k in param_dict}
@@ -12,14 +15,15 @@ if __name__ == '__main__':
                 cursor += 1
         return scan_dict
 
-    sim = Simulate('rml/dipole_beamline.rml', hide=True)
+    this_file_dir = os.path.dirname(os.path.realpath(__file__))
+    sim = Simulate(os.path.join(this_file_dir, "rml/dipole_beamline.rml"), hide=True)
 
     rml = sim.rml
     beamline = sim.rml.beamline
 
     energy = np.array([500, 1000])
     rounds = 1
-    nrays  = 1e4
+    nrays = 1e4
 
     slopes = {
         beamline.M1.slopeErrorMer: np.arange(0.3, 1.1, 0.1),
@@ -32,18 +36,21 @@ if __name__ == '__main__':
 
     params = [
         {beamline.PG.cFactor: [2, 5]},
-        {beamline.Dipole.photonEnergy: energy, beamline.Dipole.energySpread: energy / 1000},
+        {
+            beamline.Dipole.photonEnergy: energy,
+            beamline.Dipole.energySpread: energy / 1000,
+        },
         {beamline.Dipole.numberRays: nrays},
     ]
     params.append(slopes_dict)
 
     sim.params = params
-    sim.simulation_name = 'SlopeErrors'
+    sim.simulation_name = "SlopeErrors"
     sim.repeat = rounds
     sim.analyze = False
     sim.raypyng_analysis = True
 
-    sim.exports = [{beamline.DetectorAtFocus: ['RawRaysOutgoing']}]
+    sim.exports = [{beamline.DetectorAtFocus: ["RawRaysOutgoing"]}]
 
     sim.run(
         multiprocessing="auto",


### PR DESCRIPTION
## Summary

Audit of all example files found three with path/guard issues:

- **example_runner.py**: was instantiating `RayUIRunner` and calling `r.run()` at module level — on macOS with `spawn` multiprocessing this would trigger on import. Wrapped everything in `if __name__ == '__main__':`. Also fixed hardcoded relative path for `a.load()` (now uses `os.path.join(this_file_dir, ...)`).
- **simulation_slope_errors.py**: used `'rml/dipole_beamline.rml'` as a bare relative path — fails if the script is not run from the `examples/` directory. Added `os.path.join(this_file_dir, ...)`.
- **example_rml.py**: `rml.write()` used a bare relative path for the output file. `this_file_dir` was already defined in the file but unused for the write call. Fixed to use it.

All other 15 example files were audited and are clean.

## Test plan

- [x] All three fixed files pass ruff + black
- [x] `example_rml.py` can be run from any working directory and writes to `examples/rml/new_dipole_beamline.rml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)