### PR TITLE
Simplify inspect export and add styled XLSX output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.4.6] - 25-June-2026
+
+### Added
+- Beamline inspect export can now write a styled `.xlsx` workbook in addition to CSV, with bold headers/first column, borders, alternating row fills, frozen header row, and auto-sized columns.
+
+### Changed
+- Simplified the inspect feature to export a single beamline-elements table instead of separate mirror and beamline tables.
+- Inspect exports now include units in the output headers for geometry, slope-error, coating-thickness, roughness, and position columns.
+- Added `openpyxl` as a package dependency to support the new XLSX export.
+- Updated the inspect demo and example beamline files to use the new single-table CSV/XLSX export flow.
+
+### Fixed
+- Coating, top-layer, and geometry fields in inspect exports are now read from the current inspect example RML with the intended enabled/disabled handling.
+
 ## [1.4.5] - 24-June-2026
 
 ### Changed
@@ -221,5 +235,4 @@ All notable changes to this project will be documented in this file.
  
 ### Fixed
 - issue [#29](https://github.com/hz-b/raypyng/issues/29), Simulate.params used to throw an error when attempting list step-wise operation.
-
 

--- a/docs/API.rst
+++ b/docs/API.rst
@@ -110,15 +110,13 @@ ParamElement
 Beamline Inspection
 ====================
 
-These functions build summary tables and a layout plot from any ``.rml`` file
-without running a simulation.  They are useful for quickly checking element
-positions and mirror angles after loading a new beamline design.
+These functions build a summary table from any ``.rml`` file without running a
+simulation. They are useful for quickly checking element positions and key
+beamline parameters after loading a new beamline design.
 
 .. autofunction:: raypyng.inspect.build_tables
 
 .. autofunction:: raypyng.inspect.save_tables
-
-.. autofunction:: raypyng.inspect.plot_beamline_views
 
 .. autofunction:: raypyng.inspect.world_position
 
@@ -130,5 +128,4 @@ Based on  `srxraylib <https://srxraylib.readthedocs.io/en/latest/>`_
 .. autoclass:: raypyng.dipole_flux.Dipole
    :members:
    :inherited-members:
-
 

--- a/examples/inspect_demo/example_inspect.py
+++ b/examples/inspect_demo/example_inspect.py
@@ -1,47 +1,23 @@
-"""Example: inspect a beamline layout with raypyng.inspect.
-
-Builds two summary tables (all elements + mirrors/dipoles) from an RML file
-and produces a 2D/3D layout plot — no RAY-UI installation required.
-"""
+"""Example: inspect a beamline layout with raypyng.inspect."""
 
 from __future__ import annotations
 
 import os
 from pathlib import Path
 
-from raypyng import build_tables, plot_beamline_views, save_tables
+from raypyng import build_tables, save_tables, save_tables_xlsx
 
 if __name__ == "__main__":
     this_dir = Path(os.path.dirname(os.path.realpath(__file__)))
-    rml_path = this_dir.parent / "rml" / "dipole_beamline.rml"
+    rml_path = this_dir.parent / "rml" / "dipole_beamline_for_inspect.rml"
 
-    # ── build tables ──────────────────────────────────────────────────────────
-    # mirror_name_pattern selects elements whose name starts with M + digits.
-    # special_names adds the dipole source regardless of its name.
-    mirror_table, beamline_table = build_tables(
-        rml_path,
-        mirror_name_pattern=r"^M\d+",
-        special_names=("Dipole",),
-    )
+    beamline_table = build_tables(rml_path)
 
     print("=== Beamline elements ===")
     print(beamline_table.to_string(index=False))
-    print()
-    print("=== Mirrors / dipole ===")
-    print(mirror_table.to_string(index=False))
 
-    # ── save tables to CSV ────────────────────────────────────────────────────
+    # ── save tables to CSV and XLSX ───────────────────────────────────────────
     tables_dir = this_dir / "inspect_output" / "tables"
-    mirror_path, beamline_path = save_tables(mirror_table, beamline_table, tables_dir)
-    print(f"\nTables written to:\n  {mirror_path}\n  {beamline_path}")
-
-    # ── plot layout ───────────────────────────────────────────────────────────
-    plot_path = this_dir / "inspect_output" / "beamline_views.png"
-    plot_beamline_views(
-        beamline_table,
-        mirror_table,
-        output_path=plot_path,
-        title="Dipole Beamline Layout",
-        show_plot=False,
-    )
-    print(f"\nLayout plot saved to:\n  {plot_path}")
+    beamline_csv_path = save_tables(beamline_table, tables_dir)
+    beamline_xlsx_path = save_tables_xlsx(beamline_table, tables_dir)
+    print(f"\nTables written to:\n  {beamline_csv_path}\n  {beamline_xlsx_path}")

--- a/examples/rml/dipole_beamline_for_inspect.rml
+++ b/examples/rml/dipole_beamline_for_inspect.rml
@@ -1,0 +1,739 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<lab>
+ <version>1.16</version>
+ <beamline>
+  <object name="Dipole" type="Dipole" uuid="ee79b27d-d7d8-4bca-8740-585662436a7e">
+   <param id="numberRays" enabled="T">10000</param>
+   <param id="sourceWidth" unit="mm" enabled="T">0.062</param>
+   <param id="sourceHeight" unit="mm" enabled="T">0.04</param>
+   <param id="verEbeamDiv" unit="µrad" enabled="T">2</param>
+   <param id="horDiv" unit="mrad" enabled="T">2</param>
+   <param id="horDivDeg" unit="°">0.114592</param>
+   <param id="horDivSec" unit="sec">412.53</param>
+   <param id="electronEnergy" unit="GeV" enabled="T">1.7</param>
+   <param id="electronEnergyOrientation" comment="clockwise" enabled="T">0</param>
+   <param id="ringCurrent" unit="mA" enabled="T">300</param>
+   <param id="bendingRadius" unit="m" enabled="T">4.35</param>
+   <param id="magFieldStrength" unit="T">1.30358</param>
+   <param id="critEnergy" unit="keV">2.50539</param>
+   <param id="totalPowerWatt" unit="W">16.2195</param>
+   <param id="energyDistributionType" comment="Dipole" enabled="T">1</param>
+   <param id="photonEnergyDistributionFile" absolute="" enabled="F"></param>
+   <param id="photonEnergy" unit="eV" enabled="T">1000</param>
+   <param id="photonWavelength" unit="nm">1.23984</param>
+   <param id="energySpreadType" comment="white band" enabled="T">0</param>
+   <param id="energySpreadUnit" comment="%" enabled="T">1</param>
+   <param id="energySpread" enabled="T">0.1</param>
+   <param id="photonFlux" enabled="T">2.26097e+13</param>
+   <param id="sourcePulseType" comment="all rays start simultaneously" enabled="T">0</param>
+   <param id="sourcePulseLength" unit="psec" enabled="F">0</param>
+   <param id="sourcePathLength" unit="µm">0</param>
+   <param id="phaseJitter">0</param>
+   <param id="alignmentError" comment="No" enabled="T">1</param>
+   <param id="translationXerror" unit="mm" enabled="F">0</param>
+   <param id="translationYerror" unit="mm" enabled="F">0</param>
+   <param id="rotationXerror" unit="mrad" enabled="F">0</param>
+   <param id="rotationYerror" unit="mrad" enabled="F">0</param>
+   <param id="worldPosition" unit="mm">
+    <x>0.0000000000000000</x>
+    <y>0.0000000000000000</y>
+    <z>0.0000000000000000</z>
+   </param>
+   <param id="worldXdirection" unit="mm">
+    <x>1.0000000000000000</x>
+    <y>0.0000000000000000</y>
+    <z>0.0000000000000000</z>
+   </param>
+   <param id="worldYdirection" unit="mm">
+    <x>0.0000000000000000</x>
+    <y>1.0000000000000000</y>
+    <z>0.0000000000000000</z>
+   </param>
+   <param id="worldZdirection" unit="mm">
+    <x>0.0000000000000000</x>
+    <y>0.0000000000000000</y>
+    <z>1.0000000000000000</z>
+   </param>
+  </object>
+  <object name="M1" type="Toroid" uuid="327c4abc-02d2-425f-a43c-317a4ddfe70d">
+   <param id="geometricalShape" comment="rectangle" enabled="T">0</param>
+   <param id="totalWidth" unit="mm" enabled="T">50</param>
+   <param id="totalLength" unit="mm" enabled="T">1000</param>
+   <param id="grazingIncAngle" unit="°" enabled="T">1</param>
+   <param id="entranceArmLengthSag" unit="mm" enabled="T">12500</param>
+   <param id="exitArmLengthSag" unit="mm" enabled="T">100000000000000</param>
+   <param id="entranceArmLengthMer" unit="mm" enabled="T">12500</param>
+   <param id="exitArmLengthMer" unit="mm" enabled="T">19400</param>
+   <param id="longRadius" unit="mm" auto="T" enabled="T">871155.6088337566</param>
+   <param id="shortRadius" unit="mm" auto="T" enabled="T">436.310160877549</param>
+   <param id="showNumericalParameters" comment="No" enabled="T">0</param>
+   <param id="iterationDeltaZ" auto="T" enabled="T">0.0001</param>
+   <param id="iterationNumberOfSteps" auto="T" enabled="T">1000</param>
+   <param id="distancePreceding" unit="mm" enabled="T">12500</param>
+   <param id="azimuthalAngle" unit="°" enabled="T">90</param>
+   <param id="alpha1" unit="rad">0.0174533</param>
+   <param id="beta1" unit="rad">0.0174533</param>
+   <param id="reflectivityType" comment="Derived by Material" enabled="T">1</param>
+   <param id="materialSubstrate" enabled="T">Si</param>
+   <param id="roughnessSubstrate" unit="nm" enabled="T">0</param>
+   <param id="densitySubstrate" unit="g/cm³" auto="T" enabled="T">2.32</param>
+   <param id="atomicWeightSubstrate" unit="u">28.0855</param>
+   <param id="surfaceCoating" comment="One coating" enabled="T">1</param>
+   <param id="coatingFile" absolute="" enabled="F"></param>
+   <param id="numberLayer" enabled="F">2</param>
+   <param id="materialCoating1" enabled="T">Rh</param>
+   <param id="thicknessCoating1" unit="nm" enabled="T">30</param>
+   <param id="roughnessCoating1" unit="nm" enabled="T">0.2</param>
+   <param id="densityCoating1" unit="g/cm³" auto="T" enabled="T">12.39</param>
+   <param id="atomicWeightCoating1" unit="u">102.906</param>
+   <param id="materialCoating2" enabled="F"></param>
+   <param id="thicknessCoating2" unit="nm" enabled="F">0</param>
+   <param id="roughnessCoating2" unit="nm" enabled="F">0</param>
+   <param id="densityCoating2" unit="g/cm³" auto="T" enabled="F">0</param>
+   <param id="atomicWeightCoating2" unit="u">0</param>
+   <param id="coatingBilayerThickness" unit="nm">30</param>
+   <param id="coatingThicknessRatio">1</param>
+   <param id="materialTopLayer" enabled="F"></param>
+   <param id="thicknessTopLayer" unit="nm" enabled="F">0</param>
+   <param id="roughnessTopLayer" unit="nm" enabled="F">0</param>
+   <param id="densityTopLayer" unit="g/cm³" auto="T" enabled="F">0</param>
+   <param id="atomicWeightTopLayer" unit="u">0</param>
+   <param id="lateralThicknessGradientCoating" comment="No" enabled="T">0</param>
+   <param id="gradientC1B1" enabled="F">0</param>
+   <param id="gradientC1B2" enabled="F">0</param>
+   <param id="gradientC1B3" enabled="F">0</param>
+   <param id="gradientC1B4" enabled="F">0</param>
+   <param id="gradientC1B5" enabled="F">0</param>
+   <param id="gradientC1B6" enabled="F">0</param>
+   <param id="gradientC1B7" enabled="F">0</param>
+   <param id="gradientC1B8" enabled="F">0</param>
+   <param id="alignmentError" comment="Yes" enabled="T">0</param>
+   <param id="translationXerror" unit="mm" enabled="T">0</param>
+   <param id="translationYerror" unit="mm" enabled="T">0</param>
+   <param id="translationZerror" unit="mm" enabled="T">0</param>
+   <param id="rotationXerror" unit="mrad" enabled="T">0</param>
+   <param id="rotationYerror" unit="mrad" enabled="T">0</param>
+   <param id="rotationZerror" unit="mrad" enabled="T">0</param>
+   <param id="worldPosition" unit="mm">
+    <x>0.0000000000000000</x>
+    <y>0.0000000000000000</y>
+    <z>12500.0000000000000000</z>
+   </param>
+   <param id="worldXdirection" unit="mm">
+    <x>0.0000000000000000</x>
+    <y>1.0000000000000000</y>
+    <z>0.0000000000000000</z>
+   </param>
+   <param id="worldYdirection" unit="mm">
+    <x>-0.9998476951563913</x>
+    <y>0.0000000000000000</y>
+    <z>-0.0174524064372835</z>
+   </param>
+   <param id="worldZdirection" unit="mm">
+    <x>-0.0174524064372835</x>
+    <y>0.0000000000000000</y>
+    <z>0.9998476951563913</z>
+   </param>
+   <param id="slopeError" comment="Yes" enabled="T">0</param>
+   <param id="profileKind" comment="no Profile" enabled="T">2</param>
+   <param id="profileFile" absolute="" enabled="F"></param>
+   <param id="slopeErrorSag" unit="sec" enabled="T">1.5</param>
+   <param id="slopeErrorMer" unit="sec" enabled="T">0.5</param>
+   <param id="thermalDistortionAmp" unit="um" enabled="T">0</param>
+   <param id="thermalDistortionSigmaX" unit="um" enabled="T">0</param>
+   <param id="thermalDistortionSigmaZ" unit="um" enabled="T">0</param>
+   <param id="cylindricalBowingAmp" unit="um" enabled="F">0</param>
+   <param id="cylindricalBowingRadius" unit="km" enabled="F">0</param>
+  </object>
+  <object name="PremirrorM2" type="Plane Mirror" uuid="e17abf42-bbc1-4ba5-b99c-55cffcc1aa05">
+   <param id="geometricalShape" comment="rectangle" enabled="T">0</param>
+   <param id="totalWidth" unit="mm" enabled="T">25</param>
+   <param id="totalLength" unit="mm" enabled="T">500</param>
+   <param id="grazingIncAngle" unit="°" enabled="F">2.386940567621167</param>
+   <param id="distancePreceding" unit="mm" enabled="F">3260.517171211713</param>
+   <param id="azimuthalAngle" unit="°" enabled="F">0</param>
+   <param id="alpha1" unit="rad">0.04166</param>
+   <param id="beta1" unit="rad">0.04166</param>
+   <param id="systemMount" comment="SX700 (as premirror of a grating)" enabled="T">1</param>
+   <param id="nextElementPositioning" comment="Beam" enabled="T">0</param>
+   <param id="premirrorShiftZ" unit="mm" enabled="T">-300</param>
+   <param id="pimpaleAlpha1" unit="°" enabled="T">1</param>
+   <param id="pimpaleAlpha2" unit="°" enabled="T">2</param>
+   <param id="pimpaleAlpha3" unit="°" enabled="T">3</param>
+   <param id="distancePremirrorGrating" enabled="T">240.317</param>
+   <param id="reflectivityType" comment="Derived by Material" enabled="T">1</param>
+   <param id="reflectivitySenkrecht" enabled="T">0.524278</param>
+   <param id="reflectivityParallel" enabled="T">0.52289</param>
+   <param id="reflectivityPhase" enabled="T">179.772</param>
+   <param id="elementSubstrate" enabled="T">Si</param>
+   <param id="roughnessSubstrate" unit="nm" enabled="T">0</param>
+   <param id="densitySubstrate" unit="g/cm³" auto="T" enabled="T">2.32</param>
+   <param id="atomicWeightSubstrate" unit="u">28.0855</param>
+   <param id="surfaceCoating" comment="One coating" enabled="T">1</param>
+   <param id="coatingFile" absolute="" enabled="F"></param>
+   <param id="numberLayer" enabled="F">2</param>
+   <param id="materialCoating1" enabled="T">Rh</param>
+   <param id="thicknessCoating1" unit="nm" enabled="T">30</param>
+   <param id="roughnessCoating1" unit="nm" enabled="T">0.2</param>
+   <param id="densityCoating1" unit="g/cm³" auto="T" enabled="T">12.39</param>
+   <param id="atomicWeightCoating1" unit="u">102.906</param>
+   <param id="materialCoating2" enabled="F"></param>
+   <param id="thicknessCoating2" unit="nm" enabled="F">0</param>
+   <param id="roughnessCoating2" unit="nm" enabled="F">0</param>
+   <param id="densityCoating2" unit="g/cm³" auto="T" enabled="F">0</param>
+   <param id="atomicWeightCoating2" unit="u">0</param>
+   <param id="coatingBilayerThickness" unit="nm">30</param>
+   <param id="coatingThicknessRatio">1</param>
+   <param id="materialTopLayer" enabled="F"></param>
+   <param id="thicknessTopLayer" unit="nm" enabled="F">0</param>
+   <param id="roughnessTopLayer" unit="nm" enabled="F">0</param>
+   <param id="densityTopLayer" unit="g/cm³" auto="T" enabled="F">0</param>
+   <param id="atomicWeightTopLayer" unit="u">0</param>
+   <param id="lateralThicknessGradientCoating" comment="No" enabled="T">0</param>
+   <param id="gradientC1B1" enabled="F">0</param>
+   <param id="gradientC1B2" enabled="F">0</param>
+   <param id="gradientC1B3" enabled="F">0</param>
+   <param id="gradientC1B4" enabled="F">0</param>
+   <param id="gradientC1B5" enabled="F">0</param>
+   <param id="gradientC1B6" enabled="F">0</param>
+   <param id="gradientC1B7" enabled="F">0</param>
+   <param id="gradientC1B8" enabled="F">0</param>
+   <param id="alignmentError" comment="No" enabled="T">1</param>
+   <param id="translationXerror" unit="mm" enabled="F">0</param>
+   <param id="translationYerror" unit="mm" enabled="F">0</param>
+   <param id="translationZerror" unit="mm" enabled="F">0</param>
+   <param id="rotationXerror" unit="mrad" enabled="F">0</param>
+   <param id="rotationYerror" unit="mrad" enabled="F">0</param>
+   <param id="rotationZerror" unit="mrad" enabled="F">0</param>
+   <param id="worldPosition" unit="mm">
+    <x>-111.7165710008162876</x>
+    <y>-2.4769990052012361</y>
+    <z>15699.1440230781990977</z>
+   </param>
+   <param id="worldXdirection" unit="mm">
+    <x>0.9993908270190958</x>
+    <y>0.0000000000000000</y>
+    <z>0.0348994967025010</z>
+   </param>
+   <param id="worldYdirection" unit="mm">
+    <x>0.0014534915333745</x>
+    <y>0.9991323488671654</y>
+    <z>-0.0416225516942845</z>
+   </param>
+   <param id="worldZdirection" unit="mm">
+    <x>-0.0348692161146517</x>
+    <y>0.0416479224833722</y>
+    <z>0.9985237044358881</z>
+   </param>
+   <param id="slopeError" comment="Yes" enabled="T">0</param>
+   <param id="profileKind" comment="no Profile" enabled="T">2</param>
+   <param id="profileFile" absolute="" enabled="F"></param>
+   <param id="slopeErrorSag" unit="sec" enabled="T">0.1</param>
+   <param id="slopeErrorMer" unit="sec" enabled="T">0.08</param>
+   <param id="thermalDistortionAmp" unit="um" enabled="T">0</param>
+   <param id="thermalDistortionSigmaX" unit="um" enabled="T">0</param>
+   <param id="thermalDistortionSigmaZ" unit="um" enabled="T">0</param>
+   <param id="cylindricalBowingAmp" unit="um" enabled="F">0</param>
+   <param id="cylindricalBowingRadius" unit="km" enabled="F">0</param>
+  </object>
+  <object name="PG" type="Plane Grating" uuid="8f2d2dc6-5a96-4b50-9068-31a363073f95">
+   <param id="geometricalShape" comment="rectangle" enabled="T">0</param>
+   <param id="totalWidth" unit="mm" enabled="T">20</param>
+   <param id="totalLength" unit="mm" enabled="T">150</param>
+   <param id="gratingMount" comment="in-plane geometry - classical" enabled="T">0</param>
+   <param id="elementMovement" comment="c-Factor E𝛾 and m" enabled="T">3</param>
+   <param id="systemMount" comment="SX700 (external premirror)" enabled="T">1</param>
+   <param id="distancePreceding" unit="mm" enabled="F">240.316510636369</param>
+   <param id="azimuthalAngle" unit="°" enabled="T">180</param>
+   <param id="halfConeAngle" unit="°" enabled="T">10</param>
+   <param id="pimpaleX0" unit="mm" enabled="T">3500</param>
+   <param id="pimpaleY0" unit="mm" enabled="T">20</param>
+   <param id="premirrorMountPsi0" unit="°" enabled="T">0</param>
+   <param id="angleDefinition" comment="α, β and 2θ to normal" enabled="T">0</param>
+   <param id="alpha" unit="°" auto="T" enabled="T">88.63651731377458</param>
+   <param id="beta" unit="°" auto="T" enabled="T">-86.58960155098308</param>
+   <param id="deviationAngle" unit="°" auto="T" enabled="T">175.2261188647577</param>
+   <param id="grazingAlpha" unit="°" auto="T" enabled="T">1.363482686225424</param>
+   <param id="grazingBeta" unit="°" auto="T" enabled="T">3.410398449016924</param>
+   <param id="grazingDeviationAngle" unit="°" auto="T" enabled="T">4.773881135242334</param>
+   <param id="azimuthalAlpha" unit="°" auto="T" enabled="T">88.63651731377458</param>
+   <param id="azimuthalBeta" unit="°" auto="T" enabled="T">-86.58960155098308</param>
+   <param id="designEnergyMounting" unit="eV" auto="T" enabled="T">1000</param>
+   <param id="followingMode" comment="off" enabled="T">0</param>
+   <param id="sourcePhotonEnergy" unit="eV">0</param>
+   <param id="cFactor" enabled="T">2.5</param>
+   <param id="orderDiffraction" enabled="T">1</param>
+   <param id="calculatedPhotonEnergy" unit="eV">1000</param>
+   <param id="lineSpacing" comment="constant" enabled="T">0</param>
+   <param id="vlsDefinition" comment="RAY Standard" enabled="F">0</param>
+   <param id="vlsUseDesignParameters" comment="No (direct Input of Coefficients)" enabled="F">0</param>
+   <param id="vlsDesignParameterSelection" comment="Entrance, Exit Arm Length, α, E𝛾, m and d0" enabled="F">0</param>
+   <param id="designEntranceArmLength" unit="mm" enabled="T">0</param>
+   <param id="designExitArmLength" unit="mm" enabled="T">0</param>
+   <param id="vlsDesignAlphaAngle" unit="°" enabled="T">0</param>
+   <param id="vlsDesignGrazingAlphaAngle" unit="°" enabled="T">0</param>
+   <param id="vlsDesignEnergy" unit="eV" enabled="T">0</param>
+   <param id="vlsDesignDiffractionOrder" enabled="T">0</param>
+   <param id="lineDensity" unit="l/mm" enabled="T">1200</param>
+   <param id="vlsParameter1" auto="F" enabled="T">0</param>
+   <param id="vlsParameter2" auto="F" enabled="T">0</param>
+   <param id="vlsParameter3" auto="F" enabled="T">0</param>
+   <param id="vlsParameter4" auto="F" enabled="T">0</param>
+   <param id="vlsParameter5" auto="F" enabled="T">0</param>
+   <param id="vlsParameter6" auto="F" enabled="T">0</param>
+   <param id="lineProfile" comment="blazed" enabled="T">0</param>
+   <param id="gratingEfficiency" enabled="T">1</param>
+   <param id="blazeAngle" unit="°" enabled="T">0.9</param>
+   <param id="aspectAngle" unit="°" enabled="T">176.4</param>
+   <param id="antiBlazeAngleDisplay" unit="°">2.7</param>
+   <param id="grooveDepth" unit="nm" enabled="T">15</param>
+   <param id="grooveRatio" enabled="T">0.65</param>
+   <param id="leftWallAngle" unit="°" enabled="T">0</param>
+   <param id="rightWallAngle" unit="°" enabled="T">0</param>
+   <param id="grooveBottom" unit="µm">0.541667</param>
+   <param id="grooveTop" unit="µm">0.291667</param>
+   <param id="additionalOrder" comment="off" enabled="T">0</param>
+   <param id="fullEfficiency" comment="off" enabled="T">0</param>
+   <param id="multilayerFourierCoefficients" auto="T" enabled="T">11</param>
+   <param id="multilayerIntegrationSteps" auto="T" enabled="T">50</param>
+   <param id="reflectivitySenkrecht" enabled="T">0.146471</param>
+   <param id="reflectivityParallel" enabled="T">0.145954</param>
+   <param id="reflectivityPhase" enabled="T">-0.33057</param>
+   <param id="reflectivityType" comment="Derived by Material" enabled="T">1</param>
+   <param id="materialSubstrate" enabled="T">Si</param>
+   <param id="roughnessSubstrate" unit="nm" enabled="T">0</param>
+   <param id="densitySubstrate" unit="g/cm³" auto="T" enabled="T">2.32</param>
+   <param id="atomicWeightSubstrate" unit="u">28.0855</param>
+   <param id="surfaceCoating" comment="One coating" enabled="T">1</param>
+   <param id="numberLayer" enabled="F">2</param>
+   <param id="materialCoating1" enabled="T">Au</param>
+   <param id="thicknessCoating1" unit="nm" enabled="T">30</param>
+   <param id="densityCoating1" unit="g/cm³" auto="T" enabled="T">19.3</param>
+   <param id="atomicWeightCoating1" unit="u">196.966</param>
+   <param id="materialCoating2" enabled="F"></param>
+   <param id="thicknessCoating2" unit="nm" enabled="F">0</param>
+   <param id="densityCoating2" unit="g/cm³" auto="T" enabled="F">0</param>
+   <param id="atomicWeightCoating2" unit="u">0</param>
+   <param id="coatingBilayerThickness" unit="nm">30</param>
+   <param id="coatingThicknessRatio">1</param>
+   <param id="alignmentError" comment="No" enabled="T">1</param>
+   <param id="translationXerror" unit="mm" enabled="F">0</param>
+   <param id="translationYerror" unit="mm" enabled="F">0</param>
+   <param id="translationZerror" unit="mm" enabled="F">0</param>
+   <param id="rotationXerror" unit="mrad" enabled="F">0</param>
+   <param id="rotationYerror" unit="mrad" enabled="F">0</param>
+   <param id="rotationZerror" unit="mrad" enabled="F">0</param>
+   <param id="worldPosition" unit="mm">
+    <x>-122.1482384624784316</x>
+    <y>19.9999987219243742</y>
+    <z>15997.8678946735071804</z>
+   </param>
+   <param id="worldXdirection" unit="mm">
+    <x>-0.9993908270190958</x>
+    <y>0.0000000000000000</y>
+    <z>-0.0348994967025010</z>
+   </param>
+   <param id="worldYdirection" unit="mm">
+    <x>-0.0020760852173095</x>
+    <y>-0.9982290481379672</y>
+    <z>0.0594513021197906</z>
+   </param>
+   <param id="worldZdirection" unit="mm">
+    <x>-0.0348376913738317</x>
+    <y>0.0594875403220552</y>
+    <z>0.9976209539730878</z>
+   </param>
+   <param id="slopeError" comment="Yes" enabled="T">0</param>
+   <param id="profileKind" comment="no Profile" enabled="T">2</param>
+   <param id="profileFile" absolute="" enabled="F"></param>
+   <param id="slopeErrorSag" unit="sec" enabled="T">0.1</param>
+   <param id="slopeErrorMer" unit="sec" enabled="T">0.05</param>
+   <param id="thermalDistortionAmp" unit="um" enabled="T">0</param>
+   <param id="thermalDistortionSigmaX" unit="um" enabled="T">0</param>
+   <param id="thermalDistortionSigmaZ" unit="um" enabled="T">0</param>
+   <param id="cylindricalBowingAmp" unit="um" enabled="F">0</param>
+   <param id="cylindricalBowingRadius" unit="km" enabled="F">0</param>
+   <param id="entranceArmLength" unit="mm" enabled="T">100</param>
+   <param id="virtualSourceDistance" unit="mm">625</param>
+  </object>
+  <object name="M3" type="Cylinder" uuid="47f1f1c5-65e9-4c76-8145-670791d73b7c">
+   <param id="geometricalShape" comment="rectangle" enabled="T">0</param>
+   <param id="totalWidth" unit="mm" enabled="T">30</param>
+   <param id="totalLength" unit="mm" enabled="T">550</param>
+   <param id="grazingIncAngle" unit="°" enabled="T">1</param>
+   <param id="entranceArmLength" unit="mm" enabled="T">100000000000000</param>
+   <param id="exitArmLength" unit="mm" enabled="T">14500</param>
+   <param id="bendingRadius" comment="Short Radius rho" enabled="T">1</param>
+   <param id="radius" unit="mm" auto="T" enabled="T">506.1197866078344</param>
+   <param id="distancePreceding" unit="mm" enabled="T">3500</param>
+   <param id="azimuthalAngle" unit="°" enabled="T">270</param>
+   <param id="alpha1" unit="rad">0.0174533</param>
+   <param id="beta1" unit="rad">0.0174533</param>
+   <param id="reflectivityType" comment="Derived by Material" enabled="T">1</param>
+   <param id="materialSubstrate" enabled="T">Si</param>
+   <param id="roughnessSubstrate" unit="nm" enabled="T">0</param>
+   <param id="densitySubstrate" unit="g/cm³" auto="T" enabled="T">2.32</param>
+   <param id="atomicWeightSubstrate" unit="u">28.0855</param>
+   <param id="surfaceCoating" comment="One coating" enabled="T">1</param>
+   <param id="coatingFile" absolute="" enabled="F"></param>
+   <param id="numberLayer" enabled="F">2</param>
+   <param id="materialCoating1" enabled="T">Rh</param>
+   <param id="thicknessCoating1" unit="nm" enabled="T">30</param>
+   <param id="roughnessCoating1" unit="nm" enabled="T">0.2</param>
+   <param id="densityCoating1" unit="g/cm³" auto="T" enabled="T">12.39</param>
+   <param id="atomicWeightCoating1" unit="u">102.906</param>
+   <param id="materialCoating2" enabled="F"></param>
+   <param id="thicknessCoating2" unit="nm" enabled="F">0</param>
+   <param id="roughnessCoating2" unit="nm" enabled="F">0</param>
+   <param id="densityCoating2" unit="g/cm³" auto="T" enabled="F">0</param>
+   <param id="atomicWeightCoating2" unit="u">0</param>
+   <param id="coatingBilayerThickness" unit="nm">30</param>
+   <param id="coatingThicknessRatio">1</param>
+   <param id="materialTopLayer" enabled="F"></param>
+   <param id="thicknessTopLayer" unit="nm" enabled="F">0</param>
+   <param id="roughnessTopLayer" unit="nm" enabled="F">0</param>
+   <param id="densityTopLayer" unit="g/cm³" auto="T" enabled="F">0</param>
+   <param id="atomicWeightTopLayer" unit="u">0</param>
+   <param id="lateralThicknessGradientCoating" comment="No" enabled="T">0</param>
+   <param id="gradientC1B1" enabled="F">0</param>
+   <param id="gradientC1B2" enabled="F">0</param>
+   <param id="gradientC1B3" enabled="F">0</param>
+   <param id="gradientC1B4" enabled="F">0</param>
+   <param id="gradientC1B5" enabled="F">0</param>
+   <param id="gradientC1B6" enabled="F">0</param>
+   <param id="gradientC1B7" enabled="F">0</param>
+   <param id="gradientC1B8" enabled="F">0</param>
+   <param id="alignmentError" comment="No" enabled="T">1</param>
+   <param id="translationXerror" unit="mm" enabled="F">0</param>
+   <param id="translationYerror" unit="mm" enabled="F">0</param>
+   <param id="translationZerror" unit="mm" enabled="F">0</param>
+   <param id="rotationXerror" unit="mrad" enabled="F">0</param>
+   <param id="rotationYerror" unit="mrad" enabled="F">0</param>
+   <param id="rotationZerror" unit="mrad" enabled="F">0</param>
+   <param id="worldPosition" unit="mm">
+    <x>-244.2964769212318288</x>
+    <y>19.9999987219234754</y>
+    <z>19495.7357892403415462</z>
+   </param>
+   <param id="worldXdirection" unit="mm">
+    <x>0.0000000000000000</x>
+    <y>-1.0000000000000000</y>
+    <z>-0.0000000000000002</z>
+   </param>
+   <param id="worldYdirection" unit="mm">
+    <x>0.9998476951563913</x>
+    <y>0.0000000000000000</y>
+    <z>0.0174524064372835</z>
+   </param>
+   <param id="worldZdirection" unit="mm">
+    <x>-0.0174524064372835</x>
+    <y>-0.0000000000000003</y>
+    <z>0.9998476951563914</z>
+   </param>
+   <param id="slopeError" comment="Yes" enabled="T">0</param>
+   <param id="profileKind" comment="no Profile" enabled="T">2</param>
+   <param id="profileFile" absolute="" enabled="F"></param>
+   <param id="slopeErrorSag" unit="sec" enabled="T">1</param>
+   <param id="slopeErrorMer" unit="sec" enabled="T">0.3</param>
+   <param id="thermalDistortionAmp" unit="um" enabled="T">0</param>
+   <param id="thermalDistortionSigmaX" unit="um" enabled="T">0</param>
+   <param id="thermalDistortionSigmaZ" unit="um" enabled="T">0</param>
+   <param id="cylindricalBowingAmp" unit="um" enabled="F">0</param>
+   <param id="cylindricalBowingRadius" unit="km" enabled="F">0</param>
+  </object>
+  <object name="ExitSlit" type="Slit" uuid="ca9adbde-3fb1-412f-82d5-f893550c011c">
+   <param id="openingShape" comment="rectangle" enabled="T">0</param>
+   <param id="openingWidth" unit="mm" enabled="T">40</param>
+   <param id="openingHeight" unit="mm" enabled="T">0.05</param>
+   <param id="centralBeamstop" comment="none" enabled="T">0</param>
+   <param id="stopWidth" unit="mm" enabled="F">20</param>
+   <param id="stopHeight" unit="mm" enabled="F">1</param>
+   <param id="geometricalShape" comment="rectangle" enabled="T">0</param>
+   <param id="totalWidth" unit="mm" enabled="T">50</param>
+   <param id="totalHeight" unit="mm" enabled="T">50</param>
+   <param id="distancePreceding" unit="mm" enabled="T">14500</param>
+   <param id="azimuthalAngle" unit="°" enabled="T">0</param>
+   <param id="alignmentError" comment="No" enabled="T">1</param>
+   <param id="translationXerror" unit="mm" enabled="F">0</param>
+   <param id="translationYerror" unit="mm" enabled="F">0</param>
+   <param id="translationZerror" unit="mm" enabled="F">0</param>
+   <param id="rotationXerror" unit="mrad" enabled="F">0</param>
+   <param id="rotationYerror" unit="mrad" enabled="F">0</param>
+   <param id="rotationZerror" unit="mrad" enabled="F">0</param>
+   <param id="worldPosition" unit="mm">
+    <x>-244.2964769212318288</x>
+    <y>19.9999987219197557</y>
+    <z>33995.7357892403451842</z>
+   </param>
+   <param id="worldXdirection" unit="mm">
+    <x>1.0000000000000000</x>
+    <y>0.0000000000000000</y>
+    <z>-0.0000000000000000</z>
+   </param>
+   <param id="worldYdirection" unit="mm">
+    <x>-0.0000000000000000</x>
+    <y>1.0000000000000000</y>
+    <z>0.0000000000000002</z>
+   </param>
+   <param id="worldZdirection" unit="mm">
+    <x>0.0000000000000000</x>
+    <y>-0.0000000000000003</y>
+    <z>1.0000000000000002</z>
+   </param>
+  </object>
+  <object name="KB1" type="Ellipsoid" uuid="a8e7ddb5-ab61-45cb-8b9a-3a184e368912">
+   <param id="geometricalShape" comment="rectangle" enabled="T">0</param>
+   <param id="totalWidth" unit="mm" enabled="T">50</param>
+   <param id="totalLength" unit="mm" enabled="T">400</param>
+   <param id="grazingIncAngle" unit="°" enabled="T">1</param>
+   <param id="entranceArmLength" unit="mm" enabled="T">4600</param>
+   <param id="exitArmLength" unit="mm" enabled="T">1870</param>
+   <param id="designGrazingIncAngle" unit="°" auto="T" enabled="T">1</param>
+   <param id="longHalfAxisA" unit="mm" auto="T" enabled="T">3235</param>
+   <param id="shortHalfAxisB" unit="mm" auto="T" enabled="T">51.18645319681043</param>
+   <param id="centerEllipsoidY0" unit="mm">-46.4054</param>
+   <param id="centerEllipsoidZ0" unit="mm">1365.17</param>
+   <param id="tangentAngleEllipsoid" unit="°">0.421983</param>
+   <param id="RxyUpstreamEdge" unit="mm">47.751</param>
+   <param id="RxyCenter" unit="mm">46.4054</param>
+   <param id="RxyDownstreamEdge" unit="mm">44.7966</param>
+   <param id="figureRotation" comment="plane" enabled="T">1</param>
+   <param id="parameter_a11" enabled="F">1</param>
+   <param id="shortHalfAxisC" unit="mm">inf</param>
+   <param id="distancePreceding" unit="mm" enabled="T">3000</param>
+   <param id="azimuthalAngle" unit="°" enabled="T">270</param>
+   <param id="alpha" unit="rad">0.0174533</param>
+   <param id="beta" unit="rad">0.0174533</param>
+   <param id="parameter_a33">0.000250358</param>
+   <param id="parameter_a34">0.341781</param>
+   <param id="parameter_a44">2.27374e-13</param>
+   <param id="alpha1" unit="rad">0.0100883</param>
+   <param id="beta1" unit="rad">0.0248183</param>
+   <param id="reflectivityType" comment="Derived by Material" enabled="T">1</param>
+   <param id="materialSubstrate" enabled="T">Si</param>
+   <param id="roughnessSubstrate" unit="nm" enabled="T">0</param>
+   <param id="densitySubstrate" unit="g/cm³" auto="T" enabled="T">2.32</param>
+   <param id="atomicWeightSubstrate" unit="u">28.0855</param>
+   <param id="surfaceCoating" comment="One coating" enabled="T">1</param>
+   <param id="coatingFile" absolute="" enabled="F"></param>
+   <param id="numberLayer" enabled="F">2</param>
+   <param id="materialCoating1" enabled="T">Rh</param>
+   <param id="thicknessCoating1" unit="nm" enabled="T">30</param>
+   <param id="roughnessCoating1" unit="nm" enabled="T">0.2</param>
+   <param id="densityCoating1" unit="g/cm³" auto="T" enabled="T">12.39</param>
+   <param id="atomicWeightCoating1" unit="u">102.906</param>
+   <param id="materialCoating2" enabled="F"></param>
+   <param id="thicknessCoating2" unit="nm" enabled="F">0</param>
+   <param id="roughnessCoating2" unit="nm" enabled="F">0</param>
+   <param id="densityCoating2" unit="g/cm³" auto="T" enabled="F">0</param>
+   <param id="atomicWeightCoating2" unit="u">0</param>
+   <param id="coatingBilayerThickness" unit="nm">30</param>
+   <param id="coatingThicknessRatio">1</param>
+   <param id="materialTopLayer" enabled="F"></param>
+   <param id="thicknessTopLayer" unit="nm" enabled="F">0</param>
+   <param id="roughnessTopLayer" unit="nm" enabled="F">0</param>
+   <param id="densityTopLayer" unit="g/cm³" auto="T" enabled="F">0</param>
+   <param id="atomicWeightTopLayer" unit="u">0</param>
+   <param id="lateralThicknessGradientCoating" comment="No" enabled="T">0</param>
+   <param id="gradientC1B1" enabled="F">0</param>
+   <param id="gradientC1B2" enabled="F">0</param>
+   <param id="gradientC1B3" enabled="F">0</param>
+   <param id="gradientC1B4" enabled="F">0</param>
+   <param id="gradientC1B5" enabled="F">0</param>
+   <param id="gradientC1B6" enabled="F">0</param>
+   <param id="gradientC1B7" enabled="F">0</param>
+   <param id="gradientC1B8" enabled="F">0</param>
+   <param id="alignmentError" comment="No" enabled="T">1</param>
+   <param id="misalignmentCoordinateSystem" comment="Ellipsoid" enabled="T">0</param>
+   <param id="translationXerror" unit="mm" enabled="F">0</param>
+   <param id="translationYerror" unit="mm" enabled="F">0</param>
+   <param id="translationZerror" unit="mm" enabled="F">0</param>
+   <param id="rotationXerror" unit="mrad" enabled="F">0</param>
+   <param id="rotationYerror" unit="mrad" enabled="F">0</param>
+   <param id="rotationZerror" unit="mrad" enabled="F">0</param>
+   <param id="worldPosition" unit="mm">
+    <x>-244.2964769212318288</x>
+    <y>19.9999987219189848</y>
+    <z>36995.7357892403451842</z>
+   </param>
+   <param id="worldXdirection" unit="mm">
+    <x>0.0000000000000000</x>
+    <y>-1.0000000000000000</y>
+    <z>-0.0000000000000002</z>
+   </param>
+   <param id="worldYdirection" unit="mm">
+    <x>0.9998476951563913</x>
+    <y>0.0000000000000000</y>
+    <z>-0.0174524064372835</z>
+   </param>
+   <param id="worldZdirection" unit="mm">
+    <x>0.0174524064372835</x>
+    <y>-0.0000000000000003</y>
+    <z>0.9998476951563915</z>
+   </param>
+   <param id="slopeError" comment="Yes" enabled="T">0</param>
+   <param id="profileKind" comment="no Profile" enabled="T">2</param>
+   <param id="profileFile" absolute="" enabled="F"></param>
+   <param id="slopeErrorSag" unit="sec" enabled="T">0.1</param>
+   <param id="slopeErrorMer" unit="sec" enabled="T">0.05</param>
+   <param id="thermalDistortionAmp" unit="um" enabled="T">0</param>
+   <param id="thermalDistortionSigmaX" unit="um" enabled="T">0</param>
+   <param id="thermalDistortionSigmaZ" unit="um" enabled="T">0</param>
+   <param id="cylindricalBowingAmp" unit="um" enabled="F">0</param>
+   <param id="cylindricalBowingRadius" unit="km" enabled="F">0</param>
+  </object>
+  <object name="KB2" type="Ellipsoid" uuid="9dcb2799-f18c-4c16-992e-4b13d81505a0">
+   <param id="geometricalShape" comment="rectangle" enabled="T">0</param>
+   <param id="totalWidth" unit="mm" enabled="T">50</param>
+   <param id="totalLength" unit="mm" enabled="T">100</param>
+   <param id="grazingIncAngle" unit="°" enabled="T">1.5</param>
+   <param id="entranceArmLength" unit="mm" enabled="T">3300</param>
+   <param id="exitArmLength" unit="mm" enabled="T">1499</param>
+   <param id="designGrazingIncAngle" unit="°" auto="T" enabled="T">1.5</param>
+   <param id="longHalfAxisA" unit="mm" auto="T" enabled="T">2399.5</param>
+   <param id="shortHalfAxisB" unit="mm" auto="T" enabled="T">58.22061675020893</param>
+   <param id="centerEllipsoidY0" unit="mm">-53.9626</param>
+   <param id="centerEllipsoidZ0" unit="mm">900.765</param>
+   <param id="tangentAngleEllipsoid" unit="°">0.56304</param>
+   <param id="RxyUpstreamEdge" unit="mm">54.4382</param>
+   <param id="RxyCenter" unit="mm">53.9626</param>
+   <param id="RxyDownstreamEdge" unit="mm">53.4552</param>
+   <param id="figureRotation" comment="plane" enabled="T">1</param>
+   <param id="parameter_a11" enabled="F">1</param>
+   <param id="shortHalfAxisC" unit="mm">inf</param>
+   <param id="distancePreceding" unit="mm" enabled="T">300</param>
+   <param id="azimuthalAngle" unit="°" enabled="T">180</param>
+   <param id="alpha" unit="rad">0.0261799</param>
+   <param id="beta" unit="rad">0.0261799</param>
+   <param id="parameter_a33">0.000588724</param>
+   <param id="parameter_a34">0.530303</param>
+   <param id="parameter_a44">5.68434e-14</param>
+   <param id="alpha1" unit="rad">0.016353</param>
+   <param id="beta1" unit="rad">0.0360068</param>
+   <param id="reflectivityType" comment="Derived by Material" enabled="T">1</param>
+   <param id="materialSubstrate" enabled="T">Si</param>
+   <param id="roughnessSubstrate" unit="nm" enabled="T">0</param>
+   <param id="densitySubstrate" unit="g/cm³" auto="T" enabled="T">2.32</param>
+   <param id="atomicWeightSubstrate" unit="u">28.0855</param>
+   <param id="surfaceCoating" comment="One coating" enabled="T">1</param>
+   <param id="coatingFile" absolute="" enabled="F"></param>
+   <param id="numberLayer" enabled="F">2</param>
+   <param id="materialCoating1" enabled="T">Rh</param>
+   <param id="thicknessCoating1" unit="nm" enabled="T">30</param>
+   <param id="roughnessCoating1" unit="nm" enabled="T">0.2</param>
+   <param id="densityCoating1" unit="g/cm³" auto="T" enabled="T">12.39</param>
+   <param id="atomicWeightCoating1" unit="u">102.906</param>
+   <param id="materialCoating2" enabled="F"></param>
+   <param id="thicknessCoating2" unit="nm" enabled="F">0</param>
+   <param id="roughnessCoating2" unit="nm" enabled="F">0</param>
+   <param id="densityCoating2" unit="g/cm³" auto="T" enabled="F">0</param>
+   <param id="atomicWeightCoating2" unit="u">0</param>
+   <param id="coatingBilayerThickness" unit="nm">30</param>
+   <param id="coatingThicknessRatio">1</param>
+   <param id="materialTopLayer" enabled="F"></param>
+   <param id="thicknessTopLayer" unit="nm" enabled="F">0</param>
+   <param id="roughnessTopLayer" unit="nm" enabled="F">0</param>
+   <param id="densityTopLayer" unit="g/cm³" auto="T" enabled="F">0</param>
+   <param id="atomicWeightTopLayer" unit="u">0</param>
+   <param id="lateralThicknessGradientCoating" comment="No" enabled="T">0</param>
+   <param id="gradientC1B1" enabled="F">0</param>
+   <param id="gradientC1B2" enabled="F">0</param>
+   <param id="gradientC1B3" enabled="F">0</param>
+   <param id="gradientC1B4" enabled="F">0</param>
+   <param id="gradientC1B5" enabled="F">0</param>
+   <param id="gradientC1B6" enabled="F">0</param>
+   <param id="gradientC1B7" enabled="F">0</param>
+   <param id="gradientC1B8" enabled="F">0</param>
+   <param id="alignmentError" comment="No" enabled="T">1</param>
+   <param id="misalignmentCoordinateSystem" comment="Ellipsoid" enabled="T">0</param>
+   <param id="translationXerror" unit="mm" enabled="F">0</param>
+   <param id="translationYerror" unit="mm" enabled="F">0</param>
+   <param id="translationZerror" unit="mm" enabled="F">0</param>
+   <param id="rotationXerror" unit="mrad" enabled="F">0</param>
+   <param id="rotationYerror" unit="mrad" enabled="F">0</param>
+   <param id="rotationZerror" unit="mrad" enabled="F">0</param>
+   <param id="worldPosition" unit="mm">
+    <x>-233.8266279104815339</x>
+    <y>19.9999987219189066</y>
+    <z>37295.5530373460715055</z>
+   </param>
+   <param id="worldXdirection" unit="mm">
+    <x>-0.9993908270190958</x>
+    <y>-0.0000000000000000</y>
+    <z>0.0348994967025010</z>
+   </param>
+   <param id="worldYdirection" unit="mm">
+    <x>-0.0009135623211521</x>
+    <y>-0.9996573249755573</y>
+    <z>-0.0261610020182417</z>
+   </param>
+   <param id="worldZdirection" unit="mm">
+    <x>0.0348875375166154</x>
+    <y>-0.0261769483078734</y>
+    <z>0.9990483607430194</z>
+   </param>
+   <param id="slopeError" comment="Yes" enabled="T">0</param>
+   <param id="profileKind" comment="no Profile" enabled="T">2</param>
+   <param id="profileFile" absolute="" enabled="F"></param>
+   <param id="slopeErrorSag" unit="sec" enabled="T">0.1</param>
+   <param id="slopeErrorMer" unit="sec" enabled="T">0.05</param>
+   <param id="thermalDistortionAmp" unit="um" enabled="T">0</param>
+   <param id="thermalDistortionSigmaX" unit="um" enabled="T">0</param>
+   <param id="thermalDistortionSigmaZ" unit="um" enabled="T">0</param>
+   <param id="cylindricalBowingAmp" unit="um" enabled="F">0</param>
+   <param id="cylindricalBowingRadius" unit="km" enabled="F">0</param>
+  </object>
+  <object name="DetectorAtFocus" type="ImagePlane" uuid="7bff8e5c-623b-4198-87a8-3a57dfe6bd05">
+   <param id="distanceImagePlane" unit="mm" enabled="T">1500</param>
+   <param id="worldPosition" unit="mm">
+    <x>-181.5491256777005447</x>
+    <y>-58.5039356424972183</y>
+    <z>38792.5848322821766487</z>
+   </param>
+   <param id="worldXdirection" unit="mm">
+    <x>0.9993908270190958</x>
+    <y>0.0000000000000000</y>
+    <z>-0.0348994967025010</z>
+   </param>
+   <param id="worldYdirection" unit="mm">
+    <x>0.0018264985323228</x>
+    <y>0.9986295347545738</y>
+    <z>0.0523040745924711</z>
+   </param>
+   <param id="worldZdirection" unit="mm">
+    <x>0.0348516681551873</x>
+    <y>-0.0523359562429441</y>
+    <z>0.9980211966240685</z>
+   </param>
+  </object>
+ </beamline>
+ <drawing>
+  <mainBeamThickness>0</mainBeamThickness>
+  <header>true</header>
+  <axes>true</axes>
+  <names>true</names>
+  <angles>true</angles>
+  <scaling>0</scaling>
+  <scaleLinear>1</scaleLinear>
+  <scaleExponent>1</scaleExponent>
+  <scaleLinearOffset>600</scaleLinearOffset>
+  <scaleExponentiallyOffset>600</scaleExponentiallyOffset>
+  <verticalStretchEnabled>false</verticalStretchEnabled>
+  <verticalStretchFactor>1</verticalStretchFactor>
+  <fontSizeElement>32</fontSizeElement>
+  <fontSizeAxis>24</fontSizeAxis>
+  <fontSizeHeader>36</fontSizeHeader>
+  <roundOpticalAxisToWholeMm>false</roundOpticalAxisToWholeMm>
+  <distanceOffsets>
+   <element distanceOffset="0" uuid="ee79b27d-d7d8-4bca-8740-585662436a7e"/>
+   <element distanceOffset="0" uuid="327c4abc-02d2-425f-a43c-317a4ddfe70d"/>
+   <element distanceOffset="0" uuid="e17abf42-bbc1-4ba5-b99c-55cffcc1aa05"/>
+   <element distanceOffset="0" uuid="8f2d2dc6-5a96-4b50-9068-31a363073f95"/>
+   <element distanceOffset="0" uuid="47f1f1c5-65e9-4c76-8145-670791d73b7c"/>
+   <element distanceOffset="0" uuid="ca9adbde-3fb1-412f-82d5-f893550c011c"/>
+   <element distanceOffset="0" uuid="a8e7ddb5-ab61-45cb-8b9a-3a184e368912"/>
+   <element distanceOffset="0" uuid="9dcb2799-f18c-4c16-992e-4b13d81505a0"/>
+   <element distanceOffset="0" uuid="7bff8e5c-623b-4198-87a8-3a57dfe6bd05"/>
+  </distanceOffsets>
+ </drawing>
+</lab>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "joblib>=1.1.0",
   "matplotlib>=3.5.1",
   "natsort>=8.2.0",
+  "openpyxl>=3.1.0",
   "tqdm>=4.66.1",
   "pandas>=2.0.3",
   "srxraylib>=1.0.61"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ psutil>=5.9.1
 joblib>=1.1.0
 matplotlib>=3.5.1
 natsort>=8.2.0 
+openpyxl>=3.1.0
 sphinx_rtd_theme>=1.0.0
 sphinx
 sphinx-autodoc-typehints

--- a/src/raypyng/__init__.py
+++ b/src/raypyng/__init__.py
@@ -1,5 +1,5 @@
 from .dipole_flux import Dipole
-from .inspect import build_tables, plot_beamline_views, save_tables
+from .inspect import build_tables, save_tables, save_tables_xlsx
 from .rml import RMLFile
 from .simulate import Simulate, SimulationParams
 
@@ -10,5 +10,5 @@ __all__ = [
     "Dipole",
     "build_tables",
     "save_tables",
-    "plot_beamline_views",
+    "save_tables_xlsx",
 ]

--- a/src/raypyng/inspect.py
+++ b/src/raypyng/inspect.py
@@ -1,22 +1,67 @@
-"""Tools for inspecting and visualising an RML beamline layout."""
+"""Tools for inspecting an RML beamline into a single summary table."""
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 import pandas as pd
 
 from .rml import RMLFile
 
+NOT_AVAILABLE = "n.a."
+
+TABLE_COLUMNS = [
+    "name",
+    "type",
+    "grazingIncAngle",
+    "azimuthalAngle",
+    "totalWidth",
+    "totalLength",
+    "materialCoating1",
+    "thicknessCoating1",
+    "roughnessCoating1",
+    "materialCoating2",
+    "thicknessCoating2",
+    "roughnessCoating2",
+    "materialTopLayer",
+    "thicknessTopLayer",
+    "roughnessTopLayer",
+    "slopeErrorSag",
+    "slopeErrorMer",
+    "x",
+    "y",
+    "z",
+]
+
+EXPORT_COLUMN_LABELS = {
+    "name": "name",
+    "type": "type",
+    "grazingIncAngle": "grazingIncAngle [deg]",
+    "azimuthalAngle": "azimuthalAngle [deg]",
+    "totalWidth": "totalWidth [mm]",
+    "totalLength": "totalLength [mm]",
+    "materialCoating1": "materialCoating1",
+    "thicknessCoating1": "thicknessCoating1 [nm]",
+    "roughnessCoating1": "roughnessCoating1 [nm]",
+    "materialCoating2": "materialCoating2",
+    "thicknessCoating2": "thicknessCoating2 [nm]",
+    "roughnessCoating2": "roughnessCoating2 [nm]",
+    "materialTopLayer": "materialTopLayer",
+    "thicknessTopLayer": "thicknessTopLayer [nm]",
+    "roughnessTopLayer": "roughnessTopLayer [nm]",
+    "slopeErrorSag": "slopeErrorSag [sec]",
+    "slopeErrorMer": "slopeErrorMer [sec]",
+    "x": "x [mm]",
+    "y": "y [mm]",
+    "z": "z [mm]",
+}
+
 
 def world_position(element) -> tuple[str, str, str]:
-    """Return the world-position (x, y, z) of an RML element as formatted strings.
-
-    Returns ``("-", "-", "-")`` if the element has no worldPosition attribute.
-    """
+    """Return the world-position (x, y, z) of an RML element as formatted strings."""
     if not hasattr(element, "worldPosition"):
-        return "-", "-", "-"
+        return NOT_AVAILABLE, NOT_AVAILABLE, NOT_AVAILABLE
+
     position = element.worldPosition
     return (
         f"{float(position.x.cdata):.2f}",
@@ -25,247 +70,121 @@ def world_position(element) -> tuple[str, str, str]:
     )
 
 
-def build_tables(
-    rml_path: str | Path,
-    mirror_name_pattern: str = r"^M\d+",
-    special_names: tuple[str, ...] = ("dipole",),
-) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """Build a beamline-elements table and a mirror/dipole sub-table from an RML file.
+def _param_value(element, key: str, enabled_only: bool = False) -> str:
+    """Return a param value from an RML element, or ``n.a.`` when unavailable."""
+    if not hasattr(element, key):
+        return NOT_AVAILABLE
 
-    Args:
-        rml_path: Path to the ``.rml`` file.
-        mirror_name_pattern: Regex matched against element names to identify mirrors.
-            Defaults to ``r"^M\\d+"`` (names starting with M followed by digits).
-        special_names: Element names (case-insensitive) always included in the mirror
-            table regardless of the name pattern.  Defaults to ``("dipole",)``.
+    param = getattr(element, key)
+    if enabled_only and param.get_attribute("enabled") != "T":
+        return NOT_AVAILABLE
 
-    Returns:
-        ``(mirror_table, beamline_table)`` as DataFrames.
-        ``mirror_table`` has columns ``name, type, x, y, z, grazingIncAngle, azimuthalAngle``.
-        ``beamline_table`` has columns ``name, type, x, y, z``.
-    """
-    pattern = re.compile(mirror_name_pattern)
-    special = {n.lower() for n in special_names}
+    value = param.cdata.strip()
+    return value if value else NOT_AVAILABLE
 
+
+def _export_table(beamline_table: pd.DataFrame) -> pd.DataFrame:
+    """Return a copy of the table with unit-aware export column labels."""
+    return beamline_table.rename(columns=EXPORT_COLUMN_LABELS)
+
+
+def build_tables(rml_path: str | Path) -> pd.DataFrame:
+    """Build a single beamline-elements table from an RML file."""
     rml = RMLFile(None, template=str(rml_path))
-    mirror_rows: list[list[str]] = []
-    beamline_rows: list[list[str]] = []
+    rows: list[list[str]] = []
 
     for element in rml.beamline.children():
-        name = element.get_attribute("name") or "-"
-        element_type = element.get_attribute("type") or "-"
-        pos_x, pos_y, pos_z = world_position(element)
-
-        beamline_rows.append([name, element_type, pos_x, pos_y, pos_z])
-
-        if name.lower() in special or pattern.match(name):
-            grazing_inc_angle = (
-                f"{float(element.grazingIncAngle.cdata):.2f}"
-                if hasattr(element, "grazingIncAngle")
-                else "-"
-            )
-            azimuthal_angle = (
-                f"{float(element.azimuthalAngle.cdata):.2f}"
-                if hasattr(element, "azimuthalAngle")
-                else "-"
-            )
-            mirror_rows.append(
-                [name, element_type, pos_x, pos_y, pos_z, grazing_inc_angle, azimuthal_angle]
-            )
-
-    mirror_table = pd.DataFrame(
-        mirror_rows,
-        columns=["name", "type", "x", "y", "z", "grazingIncAngle", "azimuthalAngle"],
-    )
-    beamline_table = pd.DataFrame(
-        beamline_rows,
-        columns=["name", "type", "x", "y", "z"],
-    )
-    return mirror_table, beamline_table
-
-
-def save_tables(
-    mirror_table: pd.DataFrame,
-    beamline_table: pd.DataFrame,
-    tables_dir: str | Path,
-) -> tuple[Path, Path]:
-    """Save mirror and beamline tables as CSV files.
-
-    Args:
-        mirror_table: DataFrame returned by :func:`build_tables`.
-        beamline_table: DataFrame returned by :func:`build_tables`.
-        tables_dir: Directory in which to write the CSV files (created if absent).
-
-    Returns:
-        ``(mirror_path, beamline_path)`` — paths of the written files.
-    """
-    tables_dir = Path(tables_dir)
-    tables_dir.mkdir(parents=True, exist_ok=True)
-    mirror_path = tables_dir / "mirror_table.csv"
-    beamline_path = tables_dir / "beamline_elements_table.csv"
-    mirror_table.to_csv(mirror_path, index=False)
-    beamline_table.to_csv(beamline_path, index=False)
-    return mirror_path, beamline_path
-
-
-def plot_beamline_views(
-    beamline_table: pd.DataFrame,
-    mirror_table: pd.DataFrame,
-    output_path: str | Path,
-    title: str = "Beamline Layout",
-    show_plot: bool = False,
-) -> None:
-    """Produce top-view, side-view, and 3D plots of the beamline layout.
-
-    Args:
-        beamline_table: DataFrame with columns ``name, type, x, y, z``.
-        mirror_table: DataFrame with columns
-            ``name, type, x, y, z, grazingIncAngle, azimuthalAngle``.
-        output_path: Where to save the figure (PNG recommended).
-        title: Figure super-title.  Defaults to ``"Beamline Layout"``.
-        show_plot: If ``True``, call ``plt.show()`` after saving.
-    """
-    try:
-        import matplotlib.pyplot as plt
-    except ImportError as e:
-        raise ImportError(
-            "matplotlib is required for plot_beamline_views. "
-            "Install it with: pip install matplotlib"
-        ) from e
-
-    beamline = beamline_table.copy()
-    beamline[["x", "y", "z"]] = beamline[["x", "y", "z"]].astype(float)
-
-    mirrors = mirror_table.copy()
-    mirrors = mirrors[mirrors["azimuthalAngle"] != "-"].copy()
-    mirrors[["x", "y", "z", "azimuthalAngle"]] = mirrors[["x", "y", "z", "azimuthalAngle"]].astype(
-        float
-    )
-    mirror_names = set(mirrors["name"])
-
-    output_path = Path(output_path)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-
-    fig = plt.figure(figsize=(18, 10), constrained_layout=True)
-    grid = fig.add_gridspec(2, 2, width_ratios=[2.4, 1.2], height_ratios=[1, 1])
-
-    ax_top = fig.add_subplot(grid[0, 0])
-    ax_side = fig.add_subplot(grid[1, 0], sharex=ax_top)
-    ax_3d = fig.add_subplot(grid[:, 1], projection="3d")
-
-    arrow_length = max(
-        (beamline["z"].max() - beamline["z"].min()) * 0.035,
-        (beamline["x"].max() - beamline["x"].min()) * 0.06,
-    )
-
-    def draw_mirror_symbol(ax, z_value, axis_value, azimuthal_angle, mirror_type):
-        if "PlaneMirror" in mirror_type:
-            if azimuthal_angle in (0.0, 180.0):
-                dz1, da1 = -arrow_length * 0.10, -arrow_length * 0.10
-                dz2, da2 = arrow_length * 0.10, arrow_length * 0.10
-            else:
-                dz1, da1 = -arrow_length * 0.10, arrow_length * 0.10
-                dz2, da2 = arrow_length * 0.10, -arrow_length * 0.10
-            ax.plot(
-                [z_value + dz1, z_value + dz2],
-                [axis_value + da1, axis_value + da2],
-                color="red",
-                linewidth=5,
-                solid_capstyle="butt",
-                zorder=4,
-            )
-        else:
-            ax.scatter([z_value], [axis_value], s=160, marker="s", color="red", zorder=4)
-
-    def draw_projection(ax, vertical_axis, subplot_title, axis_label):
-        ax.plot(beamline["z"], beamline[vertical_axis], color="#f4a12f", linewidth=1.0, zorder=1)
-        non_mirrors = beamline[~beamline["name"].isin(mirror_names)]
-        ax.scatter(non_mirrors["z"], non_mirrors[vertical_axis], color="black", s=12, zorder=3)
-
-        for _, row in beamline.iterrows():
-            z_value = row["z"]
-            axis_value = row[vertical_axis]
-            name = row["name"]
-            if name in mirror_names:
-                mirror = mirrors.loc[mirrors["name"] == name].iloc[0]
-                draw_mirror_symbol(ax, z_value, axis_value, mirror["azimuthalAngle"], row["type"])
-            y_shift = 10 if name in mirror_names else -14
-            x_shift = 0 if name in mirror_names else 2
-            ax.annotate(
-                name,
-                (z_value, axis_value),
-                xytext=(x_shift, y_shift),
-                textcoords="offset points",
-                fontsize=7,
-                ha="center" if name in mirror_names else "left",
-                alpha=0.9,
-            )
-        ax.set_title(subplot_title, loc="left", fontsize=14)
-        ax.set_xlabel("optical axis / mm")
-        ax.set_ylabel(axis_label)
-        ax.grid(False)
-        ax.spines["top"].set_visible(False)
-        ax.spines["right"].set_visible(False)
-        ax.spines["left"].set_alpha(0.25)
-        ax.spines["bottom"].set_alpha(0.25)
-        ax.tick_params(axis="both", labelsize=9, color="0.5")
-
-    draw_projection(ax_top, "x", "top view, sagittal beam", "x / mm")
-    draw_projection(ax_side, "y", "side view, meridional beam", "y / mm")
-
-    ax_3d.plot(
-        beamline["z"],
-        beamline["x"],
-        beamline["y"],
-        color="tab:green",
-        linewidth=1.2,
-        alpha=0.8,
-    )
-    ax_3d.scatter(
-        beamline["z"],
-        beamline["x"],
-        beamline["y"],
-        color="tab:green",
-        s=28,
-        depthshade=False,
-    )
-    for z_value, x_value, y_value, name in zip(
-        beamline["z"], beamline["x"], beamline["y"], beamline["name"], strict=False
-    ):
-        ax_3d.text(z_value, x_value, y_value, name, fontsize=8)
-
-    for _, mirror in mirrors.iterrows():
-        dz, dx = 0.0, 0.0
-        az = mirror["azimuthalAngle"]
-        if az == 0.0:
-            dx = arrow_length
-        elif az == 180.0:
-            dx = -arrow_length
-        elif az == 90.0:
-            dz = -arrow_length
-        elif az == 270.0:
-            dz = arrow_length
-        ax_3d.quiver(
-            mirror["z"],
-            mirror["x"],
-            mirror["y"],
-            dz,
-            dx,
-            0.0,
-            color="crimson",
-            linewidth=1.6,
-            arrow_length_ratio=0.25,
-            alpha=0.85,
+        rows.append(
+            [
+                element.get_attribute("name") or NOT_AVAILABLE,
+                element.get_attribute("type") or NOT_AVAILABLE,
+                _param_value(element, "grazingIncAngle"),
+                _param_value(element, "azimuthalAngle"),
+                _param_value(element, "totalWidth"),
+                _param_value(element, "totalLength"),
+                _param_value(element, "materialCoating1", enabled_only=True),
+                _param_value(element, "thicknessCoating1", enabled_only=True),
+                _param_value(element, "roughnessCoating1", enabled_only=True),
+                _param_value(element, "materialCoating2", enabled_only=True),
+                _param_value(element, "thicknessCoating2", enabled_only=True),
+                _param_value(element, "roughnessCoating2", enabled_only=True),
+                _param_value(element, "materialTopLayer", enabled_only=True),
+                _param_value(element, "thicknessTopLayer", enabled_only=True),
+                _param_value(element, "roughnessTopLayer", enabled_only=True),
+                _param_value(element, "slopeErrorSag"),
+                _param_value(element, "slopeErrorMer"),
+                *world_position(element),
+            ]
         )
 
-    ax_3d.set_title("3D View")
-    ax_3d.set_xlabel("z")
-    ax_3d.set_ylabel("x")
-    ax_3d.set_zlabel("y")
-    ax_3d.view_init(elev=22, azim=-64)
+    return pd.DataFrame(rows, columns=TABLE_COLUMNS)
 
-    fig.suptitle(title, fontsize=16)
-    fig.savefig(output_path, dpi=250, bbox_inches="tight")
-    if show_plot:
-        plt.show()
-    plt.close(fig)
+
+def save_tables(beamline_table: pd.DataFrame, tables_dir: str | Path) -> Path:
+    """Save the beamline table as a CSV file."""
+    tables_dir = Path(tables_dir)
+    tables_dir.mkdir(parents=True, exist_ok=True)
+    beamline_path = tables_dir / "beamline_elements_table.csv"
+    _export_table(beamline_table).to_csv(beamline_path, index=False)
+    return beamline_path
+
+
+def save_tables_xlsx(beamline_table: pd.DataFrame, tables_dir: str | Path) -> Path:
+    """Save the beamline table as a styled XLSX file."""
+    try:
+        from openpyxl import load_workbook
+        from openpyxl.styles import Border, Font, PatternFill, Side
+        from openpyxl.utils import get_column_letter
+    except ImportError as exc:
+        raise ImportError(
+            "openpyxl is required for save_tables_xlsx. Install it with: pip install openpyxl"
+        ) from exc
+
+    tables_dir = Path(tables_dir)
+    tables_dir.mkdir(parents=True, exist_ok=True)
+    beamline_path = tables_dir / "beamline_elements_table.xlsx"
+    _export_table(beamline_table).to_excel(beamline_path, index=False)
+
+    workbook = load_workbook(beamline_path)
+    worksheet = workbook.active
+    worksheet.title = "Beamline Elements"
+    worksheet.freeze_panes = "A2"
+    worksheet.sheet_view.showGridLines = False
+
+    header_fill = PatternFill(fill_type="solid", fgColor="1F4E78")
+    header_font = Font(bold=True, color="FFFFFF")
+    first_col_font = Font(bold=True)
+    even_fill = PatternFill(fill_type="solid", fgColor="EAF2F8")
+    odd_fill = PatternFill(fill_type="solid", fgColor="FDFEFE")
+    border = Border(
+        left=Side(style="thin", color="B7C3D0"),
+        right=Side(style="thin", color="B7C3D0"),
+        top=Side(style="thin", color="B7C3D0"),
+        bottom=Side(style="thin", color="B7C3D0"),
+    )
+
+    for cell in worksheet[1]:
+        cell.fill = header_fill
+        cell.font = header_font
+        cell.border = border
+
+    for row_idx, row in enumerate(
+        worksheet.iter_rows(min_row=2, max_row=worksheet.max_row, max_col=worksheet.max_column),
+        start=2,
+    ):
+        fill = even_fill if row_idx % 2 == 0 else odd_fill
+        for col_idx, cell in enumerate(row, start=1):
+            cell.fill = fill
+            cell.border = border
+            if col_idx == 1:
+                cell.font = first_col_font
+
+    for column_cells in worksheet.columns:
+        values = [str(cell.value) if cell.value is not None else "" for cell in column_cells]
+        max_len = max(len(value) for value in values)
+        worksheet.column_dimensions[get_column_letter(column_cells[0].column)].width = min(
+            max(max_len + 2, 12), 28
+        )
+
+    workbook.save(beamline_path)
+    return beamline_path

--- a/tests/unit/test_inspect.py
+++ b/tests/unit/test_inspect.py
@@ -1,0 +1,139 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pandas as pd
+
+PACKAGE_DIR = Path(__file__).resolve().parents[2] / "src" / "raypyng"
+
+
+def _load_inspect_module():
+    package = types.ModuleType("raypyng")
+    package.__path__ = [str(PACKAGE_DIR)]
+    sys.modules["raypyng"] = package
+
+    spec = importlib.util.spec_from_file_location("raypyng.inspect", PACKAGE_DIR / "inspect.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["raypyng.inspect"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+inspect_module = _load_inspect_module()
+TABLE_COLUMNS = inspect_module.TABLE_COLUMNS
+build_tables = inspect_module.build_tables
+save_tables = inspect_module.save_tables
+save_tables_xlsx = inspect_module.save_tables_xlsx
+
+
+def test_build_tables_uses_expected_schema_and_na_values():
+    rml_path = Path("examples/rml/dipole_beamline.rml")
+
+    table = build_tables(rml_path)
+
+    assert list(table.columns) == TABLE_COLUMNS
+    assert len(table) == 9
+
+    dipole_row = table.loc[table["name"] == "Dipole"].iloc[0]
+    assert dipole_row["type"] == "Dipole"
+    assert dipole_row["grazingIncAngle"] == "n.a."
+    assert dipole_row["materialCoating1"] == "n.a."
+    assert dipole_row["x"] == "0.00"
+    assert dipole_row["y"] == "0.00"
+    assert dipole_row["z"] == "0.00"
+
+    m1_row = table.loc[table["name"] == "M1"].iloc[0]
+    assert m1_row["grazingIncAngle"] == "1"
+    assert m1_row["azimuthalAngle"] == "90"
+    assert m1_row["totalWidth"] == "50"
+    assert m1_row["totalLength"] == "1000"
+    assert m1_row["materialCoating1"] == "n.a."
+    assert m1_row["slopeErrorSag"] == "1.5"
+    assert m1_row["slopeErrorMer"] == "0.5"
+    assert m1_row["z"] == "12500.00"
+
+    slit_row = table.loc[table["name"] == "ExitSlit"].iloc[0]
+    assert slit_row["totalWidth"] == "50"
+    assert slit_row["totalLength"] == "n.a."
+    assert slit_row["slopeErrorSag"] == "n.a."
+    assert slit_row["materialTopLayer"] == "n.a."
+
+
+def test_build_tables_keeps_enabled_coating_values(tmp_path):
+    rml_path = tmp_path / "enabled_coating.rml"
+    rml_path.write_text(
+        """<?xml version='1.0' encoding='UTF-8'?>
+<lab>
+ <version>1.15</version>
+ <beamline>
+  <object name="Mcustom" type="Plane Mirror">
+   <param id="grazingIncAngle" enabled="F">3.4</param>
+   <param id="azimuthalAngle" enabled="T">180</param>
+   <param id="totalWidth" enabled="T">25</param>
+   <param id="totalLength" enabled="T">400</param>
+   <param id="materialCoating1" enabled="T">Rh</param>
+   <param id="thicknessCoating1" enabled="T">30</param>
+   <param id="roughnessCoating1" enabled="T">0.2</param>
+   <param id="materialCoating2" enabled="F">B4C</param>
+   <param id="thicknessCoating2" enabled="F">5</param>
+   <param id="roughnessCoating2" enabled="F">0.1</param>
+   <param id="materialTopLayer" enabled="T">C</param>
+   <param id="thicknessTopLayer" enabled="T">1.5</param>
+   <param id="roughnessTopLayer" enabled="T">0.05</param>
+   <param id="slopeErrorSag" enabled="T">0.3</param>
+   <param id="slopeErrorMer" enabled="T">0.1</param>
+   <param id="worldPosition" enabled="F">
+    <x>1.0</x>
+    <y>2.0</y>
+    <z>3.0</z>
+   </param>
+  </object>
+ </beamline>
+</lab>
+""",
+        encoding="utf-8",
+    )
+
+    table = build_tables(rml_path)
+    row = table.iloc[0]
+
+    assert row["grazingIncAngle"] == "3.4"
+    assert row["materialCoating1"] == "Rh"
+    assert row["thicknessCoating1"] == "30"
+    assert row["roughnessCoating1"] == "0.2"
+    assert row["materialCoating2"] == "n.a."
+    assert row["thicknessCoating2"] == "n.a."
+    assert row["roughnessCoating2"] == "n.a."
+    assert row["materialTopLayer"] == "C"
+    assert row["thicknessTopLayer"] == "1.5"
+    assert row["roughnessTopLayer"] == "0.05"
+    assert row["x"] == "1.00"
+    assert row["y"] == "2.00"
+    assert row["z"] == "3.00"
+
+
+def test_save_tables_writes_single_csv(tmp_path):
+    table = pd.DataFrame([["A", "Type"] + ["n.a."] * 18], columns=TABLE_COLUMNS)
+
+    beamline_path = save_tables(table, tmp_path)
+    header = beamline_path.read_text(encoding="utf-8").splitlines()[0]
+
+    assert beamline_path == tmp_path / "beamline_elements_table.csv"
+    assert beamline_path.exists()
+    assert not (tmp_path / "mirror_table.csv").exists()
+    assert "grazingIncAngle [deg]" in header
+    assert "totalWidth [mm]" in header
+    assert "thicknessCoating1 [nm]" in header
+    assert "slopeErrorMer [sec]" in header
+    assert header.endswith("x [mm],y [mm],z [mm]")
+
+
+def test_save_tables_xlsx_writes_single_workbook(tmp_path):
+    table = pd.DataFrame([["A", "Type"] + ["n.a."] * 18], columns=TABLE_COLUMNS)
+
+    beamline_path = save_tables_xlsx(table, tmp_path)
+
+    assert beamline_path == tmp_path / "beamline_elements_table.xlsx"
+    assert beamline_path.exists()


### PR DESCRIPTION
## Summary
- simplify inspect output to a single beamline-elements table
- add styled XLSX export alongside CSV, including unit-labelled headers
- update inspect examples, tests, changelog, and package dependencies

## Testing
- `pytest tests/unit/test_inspect.py`