### PR TITLE
[codex] Fix Read the Docs package install

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,3 +14,7 @@ sphinx:
 python:
   install:
     - requirements: requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,9 +20,13 @@ import sphinx_rtd_theme
 
 # -- Project information -----------------------------------------------------
 
-from importlib.metadata import version as _get_version
-release = _get_version("raypyng")
-version = ".".join(release.split(".")[:2])
+from importlib.metadata import PackageNotFoundError, version as _get_version
+
+try:
+    release = _get_version("raypyng")
+except PackageNotFoundError:
+    release = "unknown"
+version = ".".join(release.split(".")[:2]) if release != "unknown" else release
 
 project = 'RayPyNG'
 copyright = '2022, Simone Vadilonga, Ruslan Ovsyannikov'


### PR DESCRIPTION
## Summary
- install the `raypyng` package itself during Read the Docs builds
- keep the docs version lookup from crashing if package metadata is unavailable

## Why
Read the Docs was failing in `docs/conf.py` at `importlib.metadata.version("raypyng")` because the build environment had the requirements installed, but not the project package itself.

## Validation
- `python -m sphinx -b html docs docs/_build/html`
