### PR TITLE
[codex] Show docs version in sidebar

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,10 @@
+{% extends "!layout.html" %}
+
+{% block sidebartitle %}
+  {{ super() }}
+  {% if release %}
+  <div class="sidebar-version" style="margin-top: 0.5rem; font-size: 0.85em; opacity: 0.8;">
+    Version {{ release }}
+  </div>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a docs template override to show the package version in the left sidebar

## Validation
- `python -m sphinx -b html docs docs/_build/html`
- confirmed generated HTML contains `Version 1.4.6` in the sidebar
