### PR TITLE
Document versioning and release policy

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -111,3 +111,15 @@ The release flow is:
 4. create the release tag on `main`
 
 `main` should always reflect stable, releasable project history.
+
+## Versioning and Release Policy
+
+raypyng follows classic semantic versioning:
+
+- `MAJOR` for incompatible or substantial user-facing changes
+- `MINOR` for backward-compatible new features
+- `PATCH` for backward-compatible bug fixes and smaller corrections
+
+raypyng does not follow a fixed calendar-based release cycle. Releases are made
+when they are needed, typically after a useful set of changes has been merged,
+tested, documented, and prepared in `develop`.

--- a/README.md
+++ b/README.md
@@ -95,3 +95,16 @@ See [`tests/test.md`](tests/test.md) for setup and run commands.
 - Installation guide: https://raypyng.readthedocs.io/en/latest/installation.html
 - Tutorial: https://raypyng.readthedocs.io/en/latest/tutorial.html
 - Troubleshooting: https://raypyng.readthedocs.io/en/latest/troubleshooting.html
+
+## Versioning
+
+raypyng follows classic semantic versioning:
+
+- `MAJOR` for incompatible or substantial user-facing changes
+- `MINOR` for backward-compatible new features
+- `PATCH` for backward-compatible bug fixes and smaller corrections
+
+## Contact
+
+For questions about use rights or licensing, contact Simone Vadilonga:
+`simone.vadilonga@helmholtz-berlin.de`


### PR DESCRIPTION
## What changed
- documented the versioning scheme in the README
- added a public contact for rights-of-use and licensing questions
- documented the release policy in CONTRIBUTE.md

## Why
This makes the repository easier to assess against software-quality and publication checklists, especially around versioning, access conditions, and release policy.

## User impact
Users and assessors can now see directly that raypyng follows classic semantic versioning and uses a need-based release cycle.

## Validation
- documentation-only change
- pre-commit hooks during commit: `black`, `ruff`
