### PR TITLE
Update lockfile for 2.0.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -568,6 +568,7 @@ wheels = [
 name = "llvmlite"
 version = "0.48.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/a0/acc8ffcd5bdc63df0097e22c719bfcd61b604358343089313a8aebbb24ab/llvmlite-0.48.0.tar.gz", hash = "sha256:543b19f9ef8f3c7c60d1468191e4ee1b1537bf9f8a3d56f64c0ddd98de92edd2", size = 184016, upload-time = "2026-07-02T20:20:05.308Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/92/a2/28696a9e61e245d1a79816d29d106692a90a2b6e7d78c98b326db70827af/llvmlite-0.48.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:d66c3beb4209087ddd4cf4ed2a0856b6887e6a913bdcf1aacfec9851cf2cba4e", size = 40480651, upload-time = "2026-07-01T18:41:35.694Z" },
     { url = "https://files.pythonhosted.org/packages/80/f2/72409351db66d0a317ec5087e076f31fb7b773a640db8a90ce6b5cac9edd/llvmlite-0.48.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:416fa4c2c66c2c6dc6d0a402648c19206e548efa0aa1eff01ad5cdad0af8217d", size = 59890118, upload-time = "2026-07-01T18:41:44.886Z" },
@@ -1298,7 +1299,7 @@ wheels = [
 
 [[package]]
 name = "raypyng"
-version = "1.4.6"
+version = "2.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "joblib" },


### PR DESCRIPTION
## What changed
- updated `uv.lock` to reflect the local package version `2.0.0`
- included the refreshed lock entry for `llvmlite`

## Why
The previous documentation PR merged before this lockfile change was included, so this follow-up PR keeps the lockfile aligned with the current package metadata.

## Validation
- lockfile-only change
- pre-commit hooks during commit: `black`, `ruff`
